### PR TITLE
feat(theme): support runtime registration and object themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Neo Chess Board comes with beautiful built-in themes:
 <NeoChessBoard theme="classic" />
 ```
 
+To define your own presets, call `registerTheme('sunset', customTheme)` once during initialization. Custom theme objects can also be passed directly to the constructor, `setTheme`, or the React component.
+
 ## 📖 Documentation
 
 ### Core Components
@@ -126,7 +128,7 @@ Neo Chess Board comes with beautiful built-in themes:
 ```typescript
 interface NeoChessProps {
   fen?: string; // Chess position in FEN notation
-  theme?: 'classic' | 'midnight'; // Visual theme
+  theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board orientation
   interactive?: boolean; // Enable drag & drop
   showCoordinates?: boolean; // Show file/rank labels
@@ -252,19 +254,25 @@ function ChessGame() {
 ### Custom Themes
 
 ```typescript
-import { NeoChessBoard, THEMES } from 'neochessboard';
+import { NeoChessBoard, THEMES, registerTheme } from 'neochessboard';
 
-// Extend existing theme
+// Extend an existing preset
 const customTheme = {
   ...THEMES.midnight,
   moveFrom: 'rgba(255, 215, 0, 0.6)', // Golden highlight
   moveTo: 'rgba(0, 255, 127, 0.4)', // Spring green
 };
 
-// Apply custom theme
+// Optionally register the theme under a name for reuse
+registerTheme('sunset', customTheme);
+
 const board = new NeoChessBoard(element, {
+  // Direct object support
   theme: customTheme,
 });
+
+// Or later by name after registration
+board.setTheme('sunset');
 ```
 
 ### Integration with Chess.js
@@ -339,7 +347,7 @@ interface NeoChessProps {
   rulesAdapter?: RulesAdapter; // Custom rules engine
 
   // Visual Appearance
-  theme?: 'classic' | 'midnight'; // Built-in themes
+  theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board flip
   showCoordinates?: boolean; // A-H, 1-8 labels
 

--- a/mkdocs_docs/api.md
+++ b/mkdocs_docs/api.md
@@ -490,24 +490,21 @@ interface BoardOptions {
 
 ```typescript
 interface Theme {
-  name: string;
-  board: {
-    light: string; // Light square color
-    dark: string; // Dark square color
-    border: string; // Board border color
-  };
-  pieces: {
-    [key in PieceType]: {
-      white: string; // White piece color
-      black: string; // Black piece color
-    };
-  };
-  highlights: {
-    lastMove: string; // Last move highlight
-    legalMove: string; // Legal move highlight
-    check: string; // Check highlight
-    selected: string; // Selected square
-  };
+  light: string;
+  dark: string;
+  boardBorder: string;
+  whitePiece: string;
+  blackPiece: string;
+  pieceShadow: string;
+  pieceStroke?: string;
+  pieceHighlight?: string;
+  moveFrom: string;
+  moveTo: string;
+  lastMove: string;
+  premove: string;
+  dot: string;
+  arrow: string;
+  squareNameColor: string;
 }
 ```
 
@@ -668,41 +665,43 @@ Get the opposite color.
 
 ### Available Themes
 
-- **`light`** - Classic light wood theme
-- **`dark`** - Modern dark theme
-- **`wood`** - Traditional wooden board
-- **`glass`** - Transparent glass effect
-- **`neon`** - Futuristic neon theme
-- **`retro`** - Vintage computer theme
+- **`classic`** – Neutral palette ideal for most UIs
+- **`midnight`** – Dark theme with vivid highlights
 
 ### Using Themes
 
 ```typescript path=null start=null
-// Built-in theme
-board.setTheme('dark');
+import { registerTheme, THEMES } from 'neochessboard';
 
-// Custom theme
-const customTheme: Theme = {
-  name: 'custom',
-  board: {
-    light: '#f0d9b5',
-    dark: '#b58863',
-    border: '#8b4513',
-  },
-  pieces: {
-    king: { white: '#ffffff', black: '#000000' },
-    // ... other pieces
-  },
-  highlights: {
-    lastMove: 'rgba(255, 255, 0, 0.5)',
-    legalMove: 'rgba(0, 255, 0, 0.3)',
-    check: 'rgba(255, 0, 0, 0.7)',
-    selected: 'rgba(0, 0, 255, 0.3)',
-  },
-};
+// Use a built-in preset by name
+board.setTheme('classic');
 
-board.setTheme(customTheme);
+// Register a reusable custom preset
+registerTheme('sunset', {
+  ...THEMES.midnight,
+  moveFrom: 'rgba(255, 200, 87, 0.55)',
+  moveTo: 'rgba(244, 114, 182, 0.45)',
+});
+
+board.setTheme('sunset');
+
+// Apply an inline theme object directly
+board.applyTheme({
+  ...THEMES.classic,
+  arrow: 'rgba(34, 197, 94, 0.9)',
+});
 ```
+
+#### `registerTheme(name: string, theme: Theme): Theme`
+
+Add a custom preset to the global `THEMES` map. The function normalizes the theme and returns the stored copy.
+
+- `name: string` – Unique identifier for the theme.
+- `theme: Theme` – Theme definition to store.
+
+#### `resolveTheme(theme: ThemeName | Theme): Theme`
+
+Convert a theme name or object into the normalized structure used internally. Useful when you want to inspect or serialize a theme without registering it permanently.
 
 ## Error Handling
 

--- a/mkdocs_docs/index.md
+++ b/mkdocs_docs/index.md
@@ -117,6 +117,8 @@ Neo Chess Board comes with beautiful built-in themes:
 <NeoChessBoard theme="classic" />
 ```
 
+Use `registerTheme('sunset', customTheme)` to add reusable presets. Custom theme objects can also be passed directly to constructors, `setTheme`, or the React component.
+
 ## 📖 Documentation
 
 - [API Reference](api.md)
@@ -131,7 +133,7 @@ Neo Chess Board comes with beautiful built-in themes:
 ```tsx
 interface NeoChessProps {
   fen?: string; // Chess position in FEN notation
-  theme?: 'classic' | 'midnight'; // Visual theme
+  theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board orientation
   interactive?: boolean; // Enable drag & drop
   showCoordinates?: boolean; // Show file/rank labels
@@ -257,7 +259,7 @@ function ChessGame() {
 ### Custom Themes
 
 ```typescript
-import { NeoChessBoard, THEMES } from 'neochessboard';
+import { NeoChessBoard, THEMES, registerTheme } from 'neochessboard';
 
 // Extend existing theme
 const customTheme = {
@@ -266,10 +268,15 @@ const customTheme = {
   moveTo: 'rgba(0, 255, 127, 0.4)', // Spring green
 };
 
-// Apply custom theme
+// Optionally register for later use
+registerTheme('sunset', customTheme);
+
 const board = new NeoChessBoard(element, {
+  // Apply directly with an object
   theme: customTheme,
 });
+
+board.setTheme('sunset');
 ```
 
 ### Integration with Chess.js
@@ -344,7 +351,7 @@ interface NeoChessProps {
   rulesAdapter?: RulesAdapter; // Custom rules engine
 
   // Visual Appearance
-  theme?: 'classic' | 'midnight'; // Built-in themes
+  theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board flip
   showCoordinates?: boolean; // A-H, 1-8 labels
 

--- a/mkdocs_docs/themes.md
+++ b/mkdocs_docs/themes.md
@@ -1,623 +1,193 @@
 # Theme Development Guide
 
-This guide explains how to create and customize themes for Neo Chess Board.
+Neo Chess Board ships with a lightweight theming system focused on color palettes. Themes control the board background, piece colors and all highlight layers so you can match the board to the rest of your application.
 
-## 🎨 Theme Structure
+## 🎨 Theme structure
 
-A theme consists of colors for the board, pieces, and UI highlights:
+```ts
+import type { Theme } from 'neochessboard';
 
-```typescript path=null start=null
 interface Theme {
-  name: string;
-  board: {
-    light: string; // Light squares
-    dark: string; // Dark squares
-    border: string; // Board border
-  };
-  pieces: {
-    king: { white: string; black: string };
-    queen: { white: string; black: string };
-    rook: { white: string; black: string };
-    bishop: { white: string; black: string };
-    knight: { white: string; black: string };
-    pawn: { white: string; black: string };
-  };
-  highlights: {
-    lastMove: string; // Last move highlight
-    legalMove: string; // Legal move dots
-    check: string; // Check warning
-    selected: string; // Selected square
-  };
+  light: string;           // Light squares
+  dark: string;            // Dark squares
+  boardBorder: string;     // Outer border around the board
+  whitePiece: string;      // Fill color for white pieces
+  blackPiece: string;      // Fill color for black pieces
+  pieceShadow: string;     // Soft drop shadow rendered under every piece
+  pieceStroke?: string;    // Optional outline for the pieces
+  pieceHighlight?: string; // Optional highlight overlay on top of the pieces
+  moveFrom: string;        // Highlight for the origin square of the last move
+  moveTo: string;          // Highlight for the destination square / legal moves
+  lastMove: string;        // Overlay for the most recent move
+  premove: string;         // Highlight when a premove is set
+  dot: string;             // Small circle rendered for legal moves
+  arrow: string;           // Default arrow color
+  squareNameColor: string; // Coordinate labels drawn on the board
 }
 ```
 
-## 🏗️ Built-in Themes
+All properties accept any valid CSS color string. `pieceStroke` and `pieceHighlight` are optional; when omitted they fall back to the values from the default `classic` theme.
 
-### Light Theme
+## 🌈 Built-in themes
 
-Classic wooden chess board appearance:
+| Name      | Description         |
+| --------- | ------------------- |
+| `classic` | Neutral, wood-inspired palette suitable for most UIs |
+| `midnight`| Sleek dark theme with high-contrast highlights        |
 
-```typescript path=null start=null
-const lightTheme: Theme = {
-  name: 'light',
-  board: {
-    light: '#f0d9b5',
-    dark: '#b58863',
-    border: '#8b4513',
-  },
-  pieces: {
-    king: { white: '#ffffff', black: '#000000' },
-    queen: { white: '#ffffff', black: '#000000' },
-    // ... other pieces
-  },
-  highlights: {
-    lastMove: 'rgba(255, 255, 0, 0.5)',
-    legalMove: 'rgba(0, 255, 0, 0.3)',
-    check: 'rgba(255, 0, 0, 0.7)',
-    selected: 'rgba(0, 0, 255, 0.3)',
-  },
+Import the catalog through `THEMES`:
+
+```ts
+import { THEMES } from 'neochessboard';
+
+const { classic, midnight } = THEMES;
+```
+
+## 🧪 Creating a custom theme
+
+```ts
+import { THEMES } from 'neochessboard';
+
+const sunsetTheme = {
+  ...THEMES.midnight,
+  light: '#2E1F47',
+  dark: '#1A102B',
+  moveFrom: 'rgba(250, 204, 21, 0.55)',
+  moveTo: 'rgba(249, 115, 22, 0.45)',
+  arrow: 'rgba(236, 72, 153, 0.9)',
 };
 ```
 
-### Dark Theme
+You can pass the theme object directly when creating a board or when calling `setTheme`/`applyTheme`.
 
-Modern dark interface:
+## 🗂️ Registering reusable themes
 
-```typescript path=null start=null
-const darkTheme: Theme = {
-  name: 'dark',
-  board: {
-    light: '#4a4a4a',
-    dark: '#2d2d2d',
-    border: '#1a1a1a',
-  },
-  pieces: {
-    king: { white: '#f8f8f2', black: '#44475a' },
-    // ...
-  },
-  highlights: {
-    lastMove: 'rgba(139, 233, 253, 0.5)',
-    legalMove: 'rgba(80, 250, 123, 0.4)',
-    check: 'rgba(255, 85, 85, 0.8)',
-    selected: 'rgba(189, 147, 249, 0.4)',
-  },
+Use `registerTheme` to store a theme under a name so it can be referenced later:
+
+```ts
+import { registerTheme, THEMES } from 'neochessboard';
+
+registerTheme('sunset', {
+  ...THEMES.classic,
+  light: '#FDF2F8',
+  dark: '#831843',
+  squareNameColor: '#4C1D95',
+});
+```
+
+Registration normalizes the theme and inserts it in the `THEMES` map. Missing optional fields inherit the values from the `classic` preset.
+
+If you need the final normalized object without registering it, call `resolveTheme`:
+
+```ts
+import { resolveTheme, THEMES } from 'neochessboard';
+
+const normalized = resolveTheme({
+  ...THEMES.midnight,
+  pieceHighlight: undefined,
+});
+```
+
+## ⚙️ Applying themes
+
+### Vanilla JavaScript
+
+```ts
+import { NeoChessBoard, THEMES } from 'neochessboard';
+
+const board = new NeoChessBoard(container, {
+  theme: THEMES.classic,        // built-in object
+  // or theme: 'classic',       // built-in name
+});
+
+// Apply a custom object at runtime
+board.applyTheme({
+  ...THEMES.midnight,
+  dot: 'rgba(147, 51, 234, 0.5)',
+});
+
+// Switch back to a registered preset
+board.setTheme('sunset');
+```
+
+### React component
+
+```tsx
+import { NeoChessBoard } from 'neochessboard';
+
+const customTheme = {
+  light: '#F5F3FF',
+  dark: '#312E81',
+  boardBorder: '#3730A3',
+  whitePiece: '#F8FAFC',
+  blackPiece: '#1E1B4B',
+  pieceShadow: 'rgba(0,0,0,0.2)',
+  moveFrom: 'rgba(251, 191, 36, 0.55)',
+  moveTo: 'rgba(129, 140, 248, 0.45)',
+  lastMove: 'rgba(165, 180, 252, 0.35)',
+  premove: 'rgba(217, 70, 239, 0.35)',
+  dot: 'rgba(30, 64, 175, 0.4)',
+  arrow: 'rgba(129, 140, 248, 0.9)',
+  squareNameColor: '#E0E7FF',
 };
-```
 
-### Other Built-in Themes
-
-- **Wood**: Traditional wooden board
-- **Glass**: Transparent modern look
-- **Neon**: Futuristic cyberpunk style
-- **Retro**: Vintage computer aesthetic
-
-## 🎯 Creating Custom Themes
-
-### Step 1: Define Your Color Palette
-
-Start by choosing your base colors:
-
-```typescript path=null start=null
-const myColors = {
-  // Board colors
-  lightSquare: '#e8e8e8',
-  darkSquare: '#4169e1',
-  boardBorder: '#000080',
-
-  // Piece colors
-  whitePieces: '#ffffff',
-  blackPieces: '#1a1a1a',
-
-  // Highlight colors
-  highlight: 'rgba(255, 215, 0, 0.6)',
-  legal: 'rgba(34, 139, 34, 0.4)',
-  danger: 'rgba(220, 20, 60, 0.8)',
-  selection: 'rgba(30, 144, 255, 0.5)',
-};
-```
-
-### Step 2: Create the Theme Object
-
-```typescript path=null start=null
-const customTheme: Theme = {
-  name: 'ocean',
-  board: {
-    light: myColors.lightSquare,
-    dark: myColors.darkSquare,
-    border: myColors.boardBorder,
-  },
-  pieces: {
-    king: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-    queen: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-    rook: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-    bishop: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-    knight: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-    pawn: {
-      white: myColors.whitePieces,
-      black: myColors.blackPieces,
-    },
-  },
-  highlights: {
-    lastMove: myColors.highlight,
-    legalMove: myColors.legal,
-    check: myColors.danger,
-    selected: myColors.selection,
-  },
-};
-```
-
-### Step 3: Apply Your Theme
-
-```typescript path=null start=null
-// Vanilla JavaScript
-board.setTheme(customTheme);
-
-// React
-<NeoChessBoard theme={customTheme} />
-```
-
-## 🎨 Design Guidelines
-
-### Color Contrast
-
-Ensure sufficient contrast between:
-
-- Light and dark squares (minimum 3:1 ratio)
-- White and black pieces (minimum 4.5:1 ratio)
-- Highlights and board background (minimum 3:1 ratio)
-
-### Accessibility
-
-- Test with colorblind simulators
-- Provide alternative visual cues beyond color
-- Ensure highlights are clearly visible
-- Consider high contrast themes
-
-### Visual Harmony
-
-- Use a consistent color palette
-- Limit the number of colors (5-7 maximum)
-- Consider the emotional impact of colors
-- Test on different screen types and lighting
-
-## 🛠️ Advanced Theme Features
-
-### Gradients and Patterns
-
-You can use CSS gradients and patterns:
-
-```typescript path=null start=null
-const gradientTheme: Theme = {
-  name: 'gradient',
-  board: {
-    light: 'linear-gradient(45deg, #f0f0f0, #e0e0e0)',
-    dark: 'linear-gradient(45deg, #606060, #505050)',
-    border: '#333333',
-  },
-  // ... rest of theme
-};
-```
-
-### Semi-transparent Effects
-
-Use alpha channels for subtle effects:
-
-```typescript path=null start=null
-highlights: {
-  lastMove: 'rgba(255, 255, 0, 0.3)',      // Subtle yellow
-  legalMove: 'rgba(0, 255, 0, 0.2)',       // Light green dots
-  check: 'rgba(255, 0, 0, 0.6)',           // Strong red warning
-  selected: 'rgba(0, 100, 255, 0.4)'       // Blue selection
+function Board() {
+  return <NeoChessBoard theme={customTheme} showCoordinates />;
 }
 ```
 
-### Dynamic Themes
+The React wrapper automatically chooses between `setTheme` and `applyTheme` based on the value you provide.
 
-Create themes that respond to game state:
+## 📦 Serialization and persistence
 
-```typescript path=null start=null
-class DynamicTheme {
-  private baseTheme: Theme;
+The helper functions return plain objects, so you can safely persist them:
 
-  constructor(base: Theme) {
-    this.baseTheme = base;
-  }
+```ts
+const registered = registerTheme('aurora', customTheme);
+localStorage.setItem('aurora-theme', JSON.stringify(registered));
 
-  getThemeForState(gameState: GameState): Theme {
-    if (gameState.isCheck) {
-      return {
-        ...this.baseTheme,
-        highlights: {
-          ...this.baseTheme.highlights,
-          check: 'rgba(255, 0, 0, 0.9)', // Stronger red in check
-        },
-      };
-    }
-    return this.baseTheme;
-  }
-}
+const restored = JSON.parse(localStorage.getItem('aurora-theme')!);
+board.applyTheme(restored);
 ```
 
-## 🎨 Theme Examples
+`resolveTheme` applies the same normalization used during registration, ensuring that serialized objects remain compatible in future sessions.
 
-### Minimalist Theme
+## 🧑‍🎨 Design guidelines
 
-Clean, minimal design:
+- Ensure clear contrast between `light` and `dark` squares (recommended ratio ≥ 3:1).
+- Keep the highlight colors semi-transparent (`moveFrom`, `moveTo`, `lastMove`, `premove`) so the pieces remain visible.
+- Use `squareNameColor` that contrasts with both square colors if coordinates are visible.
+- Prefer slightly darker `dot` colors for legal moves to maintain subtlety.
+- Reuse your primary brand colors across `arrow` and highlight layers to maintain cohesion.
 
-```typescript path=null start=null
-const minimalistTheme: Theme = {
-  name: 'minimalist',
-  board: {
-    light: '#ffffff',
-    dark: '#f5f5f5',
-    border: '#e0e0e0',
-  },
-  pieces: {
-    king: { white: '#333333', black: '#666666' },
-    queen: { white: '#333333', black: '#666666' },
-    rook: { white: '#333333', black: '#666666' },
-    bishop: { white: '#333333', black: '#666666' },
-    knight: { white: '#333333', black: '#666666' },
-    pawn: { white: '#333333', black: '#666666' },
-  },
-  highlights: {
-    lastMove: 'rgba(100, 100, 100, 0.3)',
-    legalMove: 'rgba(150, 150, 150, 0.2)',
-    check: 'rgba(200, 50, 50, 0.5)',
-    selected: 'rgba(100, 150, 200, 0.3)',
-  },
-};
-```
+## ♿ Accessibility tips
 
-### High Contrast Theme
+- Check your palette with color-blind simulators to guarantee differentiation between highlight states.
+- Increase the opacity of `dot` and `arrow` colors for users with low-vision modes.
+- Consider providing an alternative high-contrast theme by adjusting `whitePiece`, `blackPiece`, and highlight colors.
 
-Accessibility-focused theme:
+## ✅ Testing your theme
 
-```typescript path=null start=null
-const highContrastTheme: Theme = {
-  name: 'high-contrast',
-  board: {
-    light: '#ffffff',
-    dark: '#000000',
-    border: '#808080',
-  },
-  pieces: {
-    king: { white: '#000000', black: '#ffffff' },
-    queen: { white: '#000000', black: '#ffffff' },
-    rook: { white: '#000000', black: '#ffffff' },
-    bishop: { white: '#000000', black: '#ffffff' },
-    knight: { white: '#000000', black: '#ffffff' },
-    pawn: { white: '#000000', black: '#ffffff' },
-  },
-  highlights: {
-    lastMove: 'rgba(255, 255, 0, 0.8)',
-    legalMove: 'rgba(0, 255, 0, 0.6)',
-    check: 'rgba(255, 0, 0, 1.0)',
-    selected: 'rgba(0, 0, 255, 0.6)',
-  },
-};
-```
+```ts
+import { resolveTheme } from 'neochessboard';
 
-### Seasonal Themes
-
-Create themes for different occasions:
-
-```typescript path=null start=null
-// Christmas theme
-const christmasTheme: Theme = {
-  name: 'christmas',
-  board: {
-    light: '#f8f8ff', // Snow white
-    dark: '#228b22', // Forest green
-    border: '#dc143c', // Crimson red
-  },
-  pieces: {
-    king: { white: '#ffd700', black: '#8b0000' }, // Gold/Dark red
-    // ... other pieces in festive colors
-  },
-  highlights: {
-    lastMove: 'rgba(255, 215, 0, 0.6)', // Gold
-    legalMove: 'rgba(255, 255, 255, 0.4)', // Snow
-    check: 'rgba(220, 20, 60, 0.8)', // Crimson
-    selected: 'rgba(65, 105, 225, 0.5)', // Royal blue
-  },
-};
-```
-
-## 📱 Responsive Considerations
-
-### Mobile-Friendly Themes
-
-For mobile devices, consider:
-
-- Larger highlight areas for touch targets
-- Higher contrast for outdoor viewing
-- Simplified piece designs for small screens
-
-```typescript path=null start=null
-const mobileTheme: Theme = {
-  // ... base theme
-  highlights: {
-    lastMove: 'rgba(255, 255, 0, 0.7)', // Higher opacity
-    legalMove: 'rgba(0, 255, 0, 0.5)', // Larger visible area
-    check: 'rgba(255, 0, 0, 0.9)', // Very prominent
-    selected: 'rgba(0, 0, 255, 0.6)', // Clear selection
-  },
-};
-```
-
-## 🔧 Testing Your Themes
-
-### Visual Testing Checklist
-
-- [ ] All pieces are clearly distinguishable
-- [ ] Board squares have sufficient contrast
-- [ ] Highlights are visible but not overwhelming
-- [ ] Theme works in both orientations
-- [ ] Colors look good on different monitors
-- [ ] Theme is accessible to colorblind users
-
-### Code Testing
-
-```typescript path=null start=null
-describe('Custom Theme', () => {
-  it('should apply theme correctly', () => {
-    board.setTheme(customTheme);
-    expect(board.getCurrentTheme().name).toBe('custom');
+describe('sunset theme', () => {
+  it('serializes correctly', () => {
+    const normalized = resolveTheme(customTheme);
+    expect(() => JSON.stringify(normalized)).not.toThrow();
   });
 
-  it('should maintain piece visibility', () => {
-    board.setTheme(customTheme);
-    // Test that pieces are rendered correctly
+  it('keeps light and dark squares distinct', () => {
+    const normalized = resolveTheme(customTheme);
+    expect(normalized.light).not.toBe(normalized.dark);
   });
 });
 ```
 
-## 🚀 Sharing Your Themes
+## 🤝 Sharing your work
 
-### Contributing Themes
+- Open a pull request with your theme proposal and a short description.
+- Include screenshots or GIFs showing the board in action.
+- Mention any accessibility considerations or design goals.
 
-1. Test your theme thoroughly
-2. Follow the naming conventions
-3. Add to the built-in themes collection
-4. Include screenshots in your pull request
-5. Document any special features
-
-### Theme Gallery
-
-We maintain a gallery of community themes. Submit yours via pull request with:
-
-- Theme definition file
-- Screenshot showing the theme
-- Brief description and inspiration
-- Accessibility notes if relevant
-
-## 🎨 Theme Inspiration
-
-### Color Palette Resources
-
-- [Adobe Color](https://color.adobe.com)
-- [Coolors.co](https://coolors.co)
-- [Material Design Colors](https://material.io/design/color)
-- [Tailwind CSS Colors](https://tailwindcss.com/docs/customizing-colors)
-
-### Chess Set Inspiration
-
-- Classical Staunton sets
-- Modern minimalist designs
-- Historical chess sets
-- Cultural and regional variations
-- Art movements (Art Deco, Bauhaus, etc.)
-
-### Color Psychology
-
-- **Blue**: Trust, stability, intelligence
-- **Green**: Growth, harmony, nature
-- **Red**: Energy, power, attention
-- **Brown**: Earthiness, reliability, comfort
-- **Purple**: Creativity, luxury, mystery
-- **Gray**: Neutrality, sophistication, balance
-
-## 🔄 Theme Switching
-
-### Smooth Transitions
-
-```typescript path=null start=null
-// Gradual theme transition
-function switchThemeWithAnimation(newTheme: Theme) {
-  const transition = {
-    duration: 300,
-    easing: 'ease-in-out',
-  };
-
-  board.setTheme(newTheme, transition);
-}
-```
-
-### User Preferences
-
-```typescript path=null start=null
-// Save user's theme preference
-function saveThemePreference(themeName: string) {
-  localStorage.setItem('neochessboard-theme', themeName);
-}
-
-// Load saved theme
-function loadThemePreference(): string | null {
-  return localStorage.getItem('neochessboard-theme');
-}
-
-// Apply saved theme on startup
-const savedTheme = loadThemePreference();
-if (savedTheme) {
-  board.setTheme(savedTheme);
-}
-```
-
-## 🌙 Dark Mode Support
-
-### System Theme Detection
-
-```typescript path=null start=null
-// Detect system dark mode preference
-const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-// Apply appropriate theme
-const defaultTheme = prefersDarkMode ? 'dark' : 'light';
-board.setTheme(defaultTheme);
-
-// Listen for system theme changes
-window.matchMedia('(prefers-color-scheme: dark)')
-  .addEventListener('change', (e) => {
-    const newTheme = e.matches ? 'dark' : light';
-    board.setTheme(newTheme);
-  });
-```
-
-## 🎨 Advanced Styling
-
-### CSS Integration
-
-You can enhance themes with CSS for the container:
-
-```css
-/* Custom board container styling */
-.neo-chess-board-container {
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  padding: 16px;
-}
-
-/* Theme-specific styling */
-.neo-chess-board-container[data-theme='neon'] {
-  background: linear-gradient(45deg, #ff006e, #8338ec);
-  box-shadow: 0 0 20px rgba(255, 0, 110, 0.5);
-}
-```
-
-### Animation Support
-
-```typescript path=null start=null
-const animatedTheme: Theme = {
-  name: 'animated',
-  // ... base theme
-  animations: {
-    pieceMove: {
-      duration: 250,
-      easing: 'ease-out',
-    },
-    highlight: {
-      duration: 150,
-      easing: 'ease-in-out',
-    },
-  },
-};
-```
-
-## 📐 Size and Scaling
-
-### Responsive Piece Sizes
-
-```typescript path=null start=null
-// Theme with size-responsive piece rendering
-const responsiveTheme: Theme = {
-  // ... base theme
-  sizing: {
-    borderWidth: (boardSize: number) => Math.max(1, boardSize / 100),
-    pieceScale: (squareSize: number) => (squareSize > 60 ? 0.9 : 0.85),
-    highlightThickness: (squareSize: number) => Math.max(2, squareSize / 20),
-  },
-};
-```
-
-## 🔍 Theme Validation
-
-### Validation Function
-
-```typescript path=null start=null
-function validateTheme(theme: Theme): boolean {
-  // Check required properties exist
-  if (!theme.name || !theme.board || !theme.pieces || !theme.highlights) {
-    return false;
-  }
-
-  // Validate color formats
-  const colorRegex = /^(#[0-9a-f]{3,6}|rgba?\([^)]+\)|[a-z]+)$/i;
-
-  // Check board colors
-  if (!colorRegex.test(theme.board.light) || !colorRegex.test(theme.board.dark)) {
-    return false;
-  }
-
-  // Check piece colors
-  for (const piece of Object.values(theme.pieces)) {
-    if (!colorRegex.test(piece.white) || !colorRegex.test(piece.black)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-```
-
-## 🎯 Performance Tips
-
-### Efficient Color Usage
-
-- Use hex colors when possible (faster parsing)
-- Avoid complex gradients for frequently redrawn elements
-- Cache computed colors for repeated use
-- Use solid colors for piece sprites
-
-### Memory Optimization
-
-```typescript path=null start=null
-// Reuse theme objects instead of creating new ones
-const themeCache = new Map<string, Theme>();
-
-function getTheme(name: string): Theme {
-  if (!themeCache.has(name)) {
-    themeCache.set(name, createTheme(name));
-  }
-  return themeCache.get(name)!;
-}
-```
-
-## 📋 Theme Checklist
-
-When creating a new theme, ensure:
-
-- [ ] Theme name is unique and descriptive
-- [ ] All required properties are defined
-- [ ] Colors use valid CSS color formats
-- [ ] Sufficient contrast for accessibility
-- [ ] Tested on multiple devices/screens
-- [ ] Works with both board orientations
-- [ ] Highlights are clearly visible
-- [ ] Pieces are distinguishable
-- [ ] Theme follows design guidelines
-- [ ] Performance is acceptable
-
-## 🎨 Community Themes
-
-Visit our [theme gallery](https://github.com/yourusername/neochessboard/wiki/Theme-Gallery) to see community-created themes and share your own creations!
-
----
-
-Happy theme designing! 🎨✨
+Happy theming!

--- a/src/core/themes.ts
+++ b/src/core/themes.ts
@@ -37,4 +37,32 @@ export const THEMES: Record<string, Theme> = {
   },
 };
 
+const DEFAULT_THEME_KEY = 'classic' as const;
+
+const getDefaultTheme = () => THEMES[DEFAULT_THEME_KEY];
+
+const normalizeTheme = (theme: Theme): Theme => {
+  const base = getDefaultTheme();
+  return {
+    ...base,
+    ...theme,
+    pieceStroke: theme.pieceStroke ?? base.pieceStroke,
+    pieceHighlight: theme.pieceHighlight ?? base.pieceHighlight,
+  };
+};
+
 export type ThemeName = keyof typeof THEMES;
+export type CustomThemeName = ThemeName | (string & {});
+
+export const registerTheme = (name: string, theme: Theme): Theme => {
+  const normalized = normalizeTheme(theme);
+  THEMES[name] = normalized;
+  return normalized;
+};
+
+export const resolveTheme = (theme: ThemeName | Theme): Theme => {
+  if (typeof theme === 'string') {
+    return THEMES[theme] ?? getDefaultTheme();
+  }
+  return normalizeTheme(theme);
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,5 @@
+import type { ThemeName } from './themes';
+
 export type Square =
   `${'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'}${'1' | '2' | '3' | '4' | '5' | '6' | '7' | '8'}`;
 export type Color = 'w' | 'b';
@@ -81,7 +83,7 @@ export interface BoardOptions {
   size?: number;
   orientation?: 'white' | 'black';
   interactive?: boolean;
-  theme?: 'classic' | 'midnight';
+  theme?: ThemeName | Theme;
   showCoordinates?: boolean;
   animationMs?: number;
   highlightLegal?: boolean;

--- a/src/react/NeoChessBoard.tsx
+++ b/src/react/NeoChessBoard.tsx
@@ -39,7 +39,11 @@ export const NeoChessBoard = forwardRef<NeoChessRef, NeoChessProps>(
           boardRef.current.setFEN(fen);
         }
         if (opts.theme !== undefined) {
-          boardRef.current.setTheme(opts.theme as string);
+          if (typeof opts.theme === 'string') {
+            boardRef.current.setTheme(opts.theme);
+          } else {
+            boardRef.current.applyTheme(opts.theme);
+          }
         }
         if (opts.soundEnabled !== undefined) {
           boardRef.current.setSoundEnabled(opts.soundEnabled);

--- a/tests/core/themes.test.ts
+++ b/tests/core/themes.test.ts
@@ -1,5 +1,6 @@
-import { THEMES, ThemeName } from '../../src/core/themes';
+import { THEMES, ThemeName, registerTheme, resolveTheme } from '../../src/core/themes';
 import type { Theme } from '../../src/core/types';
+import { NeoChessBoard } from '../../src/core/NeoChessBoard';
 
 describe('Themes', () => {
   const requiredThemeProperties: (keyof Theme)[] = [
@@ -122,6 +123,69 @@ describe('Themes', () => {
         expect(moveToOpacity).toBeGreaterThan(0);
         expect(moveToOpacity).toBeLessThan(1);
       });
+    });
+  });
+
+  describe('Custom theme registration', () => {
+    const customTheme: Theme = {
+      light: '#FEF3C7',
+      dark: '#92400E',
+      boardBorder: '#B45309',
+      whitePiece: '#FFFFFF',
+      blackPiece: '#1F2937',
+      pieceShadow: 'rgba(0,0,0,0.2)',
+      moveFrom: 'rgba(248, 113, 113, 0.45)',
+      moveTo: 'rgba(74, 222, 128, 0.45)',
+      lastMove: 'rgba(59, 130, 246, 0.45)',
+      premove: 'rgba(236, 72, 153, 0.35)',
+      dot: 'rgba(15, 23, 42, 0.35)',
+      arrow: 'rgba(59, 130, 246, 0.9)',
+      squareNameColor: '#1F2937',
+    };
+
+    const CUSTOM_THEME_KEY = 'sunsetGlow';
+
+    afterEach(() => {
+      delete (THEMES as Record<string, Theme>)[CUSTOM_THEME_KEY];
+    });
+
+    it('should register and normalize a custom theme', () => {
+      const normalized = registerTheme(CUSTOM_THEME_KEY, customTheme);
+
+      expect(THEMES[CUSTOM_THEME_KEY]).toBeDefined();
+      expect(THEMES[CUSTOM_THEME_KEY]).toEqual(normalized);
+      expect(normalized).not.toBe(customTheme);
+      expect(normalized.light).toBe(customTheme.light);
+      expect(normalized.pieceStroke).toBe(THEMES.classic.pieceStroke);
+      expect(normalized.pieceHighlight).toBe(THEMES.classic.pieceHighlight);
+      expect(resolveTheme(CUSTOM_THEME_KEY as any)).toBe(THEMES[CUSTOM_THEME_KEY]);
+
+      const serialized = JSON.parse(JSON.stringify(THEMES[CUSTOM_THEME_KEY]));
+      expect(serialized.light).toBe(customTheme.light);
+      expect(serialized.dark).toBe(customTheme.dark);
+      expect(serialized.pieceHighlight).toBe(THEMES.classic.pieceHighlight);
+    });
+
+    it('should resolve theme objects without registration', () => {
+      const resolved = resolveTheme(customTheme);
+
+      expect(resolved.light).toBe(customTheme.light);
+      expect(resolved.pieceHighlight).toBe(THEMES.classic.pieceHighlight);
+    });
+
+    it('should allow applying theme objects via setTheme', () => {
+      const container = document.createElement('div');
+      const board = new NeoChessBoard(container);
+
+      board.setTheme(customTheme);
+      const appliedTheme = (board as unknown as { theme: Theme }).theme;
+
+      expect(appliedTheme.light).toBe(customTheme.light);
+      expect(appliedTheme.dark).toBe(customTheme.dark);
+      expect(appliedTheme.pieceHighlight).toBe(THEMES.classic.pieceHighlight);
+      expect(() => JSON.stringify(appliedTheme)).not.toThrow();
+
+      board.destroy();
     });
   });
 });

--- a/tests/react/NeoChessBoard.test.tsx
+++ b/tests/react/NeoChessBoard.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { NeoChessBoard } from '../../src/react/NeoChessBoard';
 import type { NeoChessRef } from '../../src/react/NeoChessBoard';
+import type { Theme } from '../../src/core/types';
 
 // Mock the core NeoChessBoard class
 let currentFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'; // Default FEN
@@ -11,6 +12,7 @@ const mockBoard = {
   destroy: jest.fn(),
   getPosition: jest.fn(() => currentFen), // Mock getPosition to return currentFen
   setTheme: jest.fn(),
+  applyTheme: jest.fn(),
   setSoundEnabled: jest.fn(),
   setOrientation: jest.fn(),
   setShowArrows: jest.fn(),
@@ -238,6 +240,34 @@ describe('NeoChessBoard React Component', () => {
       expect(mockBoard.setAllowPremoves).toHaveBeenCalledWith(true);
       expect(mockBoard.setHighlightLegal).toHaveBeenCalledWith(true);
       expect(mockBoard.setShowSquareNames).toHaveBeenCalledWith(true);
+    });
+
+    it('should call applyTheme when theme prop is a custom object', () => {
+      const customTheme: Theme = {
+        light: '#FFFFFF',
+        dark: '#0F172A',
+        boardBorder: '#1E293B',
+        whitePiece: '#F8FAFC',
+        blackPiece: '#0B1120',
+        pieceShadow: 'rgba(0,0,0,0.2)',
+        moveFrom: 'rgba(251, 191, 36, 0.5)',
+        moveTo: 'rgba(74, 222, 128, 0.45)',
+        lastMove: 'rgba(96, 165, 250, 0.45)',
+        premove: 'rgba(217, 70, 239, 0.35)',
+        dot: 'rgba(15, 23, 42, 0.35)',
+        arrow: 'rgba(34, 197, 94, 0.9)',
+        squareNameColor: '#F8FAFC',
+      };
+
+      const { rerender } = render(<NeoChessBoard theme="classic" />);
+
+      mockBoard.applyTheme.mockClear();
+      mockBoard.setTheme.mockClear();
+
+      rerender(<NeoChessBoard theme={customTheme} />);
+
+      expect(mockBoard.applyTheme).toHaveBeenCalledWith(customTheme);
+      expect(mockBoard.setTheme).not.toHaveBeenCalledWith(customTheme);
     });
   });
 


### PR DESCRIPTION
## Summary
- add helpers to register and resolve theme definitions with normalization
- allow NeoChessBoard and the React wrapper to accept theme names or objects and expose applyTheme
- extend tests and documentation to cover custom theme serialization and usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ebae99cc8327b76e693b6d15b9f6