### PR TITLE
docs: add theme creator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,37 @@ Neo Chess Board comes with beautiful built-in themes:
 
 To define your own presets, call `registerTheme('sunset', customTheme)` once during initialization. Custom theme objects can also be passed directly to the constructor, `setTheme`, or the React component.
 
+### 🌐 Theme Creator Web App
+
+Looking for a faster way to design palettes? The project ships with an interactive [Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html) that lets you experiment visually before exporting code. It provides:
+
+- 🎛️ Live controls for all 15 theme properties with instant board preview
+- 💾 Theme management helpers to load presets (`classic`, `midnight`), rename them, and store new ideas
+- 📤 Export buttons that generate JSON payloads or ready-to-paste TypeScript snippets using `registerTheme`
+
+#### How to use it
+
+1. Open the [Theme Creator page](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html) or, for local development, run `npm run dev` from the `demo` folder and visit `http://localhost:5174/theme-creator.html`.
+2. Pick a starting palette from the dropdown or begin with a blank canvas.
+3. Adjust colors via the color pickers/text inputs and watch the preview board update in real time.
+4. Give your creation a name, save it, and export the JSON/code snippet when you are happy with the result.
+
+Once exported you can register the theme in your app:
+
+```ts
+import { registerTheme } from 'neochessboard';
+
+const aurora = {
+  light: '#F5F3FF',
+  dark: '#1E1B4B',
+  // ...other properties from the generator
+};
+
+registerTheme('aurora', aurora);
+```
+
+The saved presets can also be stored in `localStorage` for later editing, making it easy to iterate on branding.
+
 ## 📖 Documentation
 
 ### Core Components

--- a/mkdocs_docs/index.md
+++ b/mkdocs_docs/index.md
@@ -119,6 +119,36 @@ Neo Chess Board comes with beautiful built-in themes:
 
 Use `registerTheme('sunset', customTheme)` to add reusable presets. Custom theme objects can also be passed directly to constructors, `setTheme`, or the React component.
 
+### 🌐 Theme Creator Web App
+
+Designing colors manually can be slow. Visit the interactive [Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html) to preview palettes live and export the resulting code. The builder includes:
+
+- 🎛️ Real-time controls for every theme property (board colors, highlights, arrows, etc.)
+- 💾 Quick access to existing presets so you can start from `classic` or `midnight`
+- 📤 Export helpers that copy JSON or TypeScript snippets using `registerTheme`
+
+#### Try it out
+
+1. Open the [hosted Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html). For local work run `npm run dev` inside `demo/` and navigate to `http://localhost:5174/theme-creator.html`.
+2. Choose a base theme, tweak the color pickers, and watch the preview board update instantly.
+3. Name the palette, save it, and download the generated JSON or TypeScript code.
+
+You can then register the exported object in your project:
+
+```ts
+import { registerTheme } from 'neochessboard';
+
+const aurora = {
+  light: '#F5F3FF',
+  dark: '#1E1B4B',
+  // ...rest of the properties from the generator
+};
+
+registerTheme('aurora', aurora);
+```
+
+The Theme Creator keeps saved palettes in `localStorage`, so you can revisit and refine them anytime.
+
 ## 📖 Documentation
 
 - [API Reference](api.md)

--- a/mkdocs_docs/themes.md
+++ b/mkdocs_docs/themes.md
@@ -43,6 +43,36 @@ import { THEMES } from 'neochessboard';
 const { classic, midnight } = THEMES;
 ```
 
+## 🌐 Theme Creator Web App
+
+Instead of tweaking JSON by hand, try the hosted [Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html). It ships with the repository (`demo/theme-creator.html`) and offers:
+
+- Live color pickers for every property with an immediate board preview
+- Quick access to existing presets so you can clone or extend them
+- Export helpers that produce JSON or TypeScript snippets calling `registerTheme`
+
+### Getting started
+
+1. Launch the [Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html), or run `npm run dev` in the `demo/` directory and open `http://localhost:5174/theme-creator.html` for local development.
+2. Pick a base theme from the dropdown, edit values through the color inputs, and watch the preview update.
+3. Save the palette under a custom name and export the generated code when you are ready to integrate it.
+
+Exported themes can be registered right away:
+
+```ts
+import { registerTheme } from 'neochessboard';
+
+const aurora = {
+  light: '#F5F3FF',
+  dark: '#1E1B4B',
+  // ...other properties chosen in the creator
+};
+
+registerTheme('aurora', aurora);
+```
+
+The builder persists saved palettes in `localStorage`, so you can iterate across sessions without losing changes.
+
 ## 🧪 Creating a custom theme
 
 ```ts


### PR DESCRIPTION
## Summary
- document the hosted theme creator and link it from the README
- describe the builder features and usage in the mkdocs landing page
- add a dedicated section to the themes guide showing how to export and register palettes

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9ff93762c83279cc0f7788f6fbff7