### PR TITLE
Add support for custom chess piece sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ _Perfect for creating chess applications with Chessbook-like feel and performanc
 
 - 🖱️ Smooth drag & drop interactions
 - 🎨 Beautiful piece sprites with shadows
+- 🧩 Bring your own piece set (SVG, PNG, or Canvas sources)
 - ✨ Fluid animations and transitions
 - 🎯 Legal move highlighting
 - 📱 Responsive design
@@ -119,6 +120,34 @@ Neo Chess Board comes with beautiful built-in themes:
 
 To define your own presets, call `registerTheme('sunset', customTheme)` once during initialization. Custom theme objects can also be passed directly to the constructor, `setTheme`, or the React component.
 
+## 🧩 Custom Piece Sets
+
+Prefer wooden Staunton pieces, minimalist line art, or even emoji? Pass a `pieceSet` option to the board (or React component) and supply the sprites you want to use. Each entry can be an imported image/URL, an `HTMLCanvasElement`, or any other [`CanvasImageSource`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage#parameters) instance.
+
+```tsx
+import type { PieceSet } from 'neochessboard';
+import whiteKing from './pieces/wK.svg';
+import blackKing from './pieces/bK.svg';
+import whitePawn from './pieces/wP.png';
+import blackPawn from './pieces/bP.png';
+
+const customPieces = {
+  defaultScale: 0.9,
+  pieces: {
+    K: { image: whiteKing },
+    k: { image: blackKing },
+    P: { image: whitePawn, offsetY: 0.02 },
+    p: { image: blackPawn },
+  },
+} satisfies PieceSet;
+
+<NeoChessBoard theme="midnight" pieceSet={customPieces} />;
+```
+
+- Keys follow FEN notation (`K`, `Q`, `R`, `B`, `N`, `P` for white and lowercase for black). Any pieces you omit will fall back to the default flat sprites.
+- `defaultScale` and per-piece `scale` let you shrink or enlarge the artwork relative to the square size, while `offsetX`/`offsetY` (fractions of the square) help fine tune alignment.
+- At runtime you can call `board.setPieceSet(newSet)` (or `setPieceSet(undefined)`) to swap collections instantly.
+
 ### 🌐 Theme Creator Web App
 
 Looking for a faster way to design palettes? The project ships with an interactive [Theme Creator](https://magicolala.github.io/Neo-Chess-Board-Ts-Library/demo/theme-creator.html) that lets you experiment visually before exporting code. It provides:
@@ -160,6 +189,7 @@ The saved presets can also be stored in `localStorage` for later editing, making
 interface NeoChessProps {
   fen?: string; // Chess position in FEN notation
   theme?: ThemeName | Theme; // Built-in theme name or custom object
+  pieceSet?: PieceSet; // Provide custom piece sprites
   orientation?: 'white' | 'black'; // Board orientation
   interactive?: boolean; // Enable drag & drop
   showCoordinates?: boolean; // Show file/rank labels

--- a/src/core/NeoChessBoard.ts
+++ b/src/core/NeoChessBoard.ts
@@ -30,6 +30,7 @@ import type {
   PieceSet,
   PieceSprite,
   PieceSpriteSource,
+  PieceSpriteImage,
 } from './types';
 
 interface BoardState {
@@ -48,7 +49,7 @@ interface BoardEvents {
 }
 
 interface ResolvedPieceSprite {
-  image: CanvasImageSource;
+  image: PieceSpriteImage;
   scale: number;
   offsetX: number;
   offsetY: number;
@@ -361,10 +362,9 @@ export class NeoChessBoard {
     const defaultScale = pieceSet.defaultScale ?? 1;
     const resolved: Partial<Record<Piece, ResolvedPieceSprite>> = {};
 
-    const entries = Object.entries(pieceSet.pieces) as Array<[
-      Piece,
-      PieceSpriteSource | PieceSprite,
-    ]>;
+    const entries = Object.entries(pieceSet.pieces) as Array<
+      [Piece, PieceSpriteSource | PieceSprite]
+    >;
 
     await Promise.all(
       entries.map(async ([pieceKey, sprite]) => {
@@ -375,10 +375,7 @@ export class NeoChessBoard {
             resolved[pieceKey as Piece] = resolvedSprite;
           }
         } catch (error) {
-          console.warn(
-            `[NeoChessBoard] Failed to load sprite for piece "${pieceKey}".`,
-            error,
-          );
+          console.warn(`[NeoChessBoard] Failed to load sprite for piece "${pieceKey}".`, error);
         }
       }),
     );
@@ -551,7 +548,7 @@ export class NeoChessBoard {
         ? (sprite as PieceSprite)
         : ({ image: sprite } as PieceSprite);
 
-    let source: CanvasImageSource | null = null;
+    let source: PieceSpriteImage | null = null;
     if (typeof config.image === 'string') {
       source = await this._loadImage(config.image);
     } else if (config.image) {

--- a/src/core/NeoChessBoard.ts
+++ b/src/core/NeoChessBoard.ts
@@ -26,6 +26,10 @@ import type {
   HighlightType,
   Premove,
   Theme,
+  Piece,
+  PieceSet,
+  PieceSprite,
+  PieceSpriteSource,
 } from './types';
 
 interface BoardState {
@@ -41,6 +45,13 @@ interface BoardEvents {
   move: { from: Square; to: Square; fen: string };
   illegal: { from: Square; to: Square; reason: string };
   update: { fen: string };
+}
+
+interface ResolvedPieceSprite {
+  image: CanvasImageSource;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
 }
 
 export class NeoChessBoard {
@@ -162,6 +173,21 @@ export class NeoChessBoard {
    */
   private soundUrl: string | undefined;
 
+  /**
+   * Custom piece sprites provided by the user.
+   */
+  private customPieceSprites: Partial<Record<Piece, ResolvedPieceSprite>> = {};
+
+  /**
+   * Token used to invalidate pending custom piece loading operations.
+   */
+  private _pieceSetToken = 0;
+
+  /**
+   * Stores the latest piece set reference applied to the board.
+   */
+  private _pieceSetRaw?: PieceSet;
+
   // Audio elements
   /**
    * Audio element for playing move sounds.
@@ -249,6 +275,10 @@ export class NeoChessBoard {
     this._buildDOM();
     this._attachEvents();
     this.resize();
+
+    if (options.pieceSet) {
+      void this.setPieceSet(options.pieceSet);
+    }
   }
 
   // Public API methods
@@ -302,6 +332,62 @@ export class NeoChessBoard {
   public applyTheme(theme: ThemeName | Theme) {
     this.theme = resolveTheme(theme);
     this._rasterize();
+    this.renderAll();
+  }
+
+  /**
+   * Applies a custom piece set, allowing users to provide their own sprites.
+   * Passing `undefined` or an empty configuration reverts to the default flat sprites.
+   * @param pieceSet Custom piece configuration to apply.
+   */
+  public async setPieceSet(pieceSet?: PieceSet | null) {
+    if (!pieceSet || !pieceSet.pieces || Object.keys(pieceSet.pieces).length === 0) {
+      if (!this._pieceSetRaw && Object.keys(this.customPieceSprites).length === 0) {
+        return;
+      }
+      this._pieceSetRaw = undefined;
+      this.customPieceSprites = {};
+      this._pieceSetToken++;
+      this.renderAll();
+      return;
+    }
+
+    if (pieceSet === this._pieceSetRaw) {
+      return;
+    }
+
+    this._pieceSetRaw = pieceSet;
+    const token = ++this._pieceSetToken;
+    const defaultScale = pieceSet.defaultScale ?? 1;
+    const resolved: Partial<Record<Piece, ResolvedPieceSprite>> = {};
+
+    const entries = Object.entries(pieceSet.pieces) as Array<[
+      Piece,
+      PieceSpriteSource | PieceSprite,
+    ]>;
+
+    await Promise.all(
+      entries.map(async ([pieceKey, sprite]) => {
+        if (!sprite) return;
+        try {
+          const resolvedSprite = await this._resolvePieceSprite(sprite, defaultScale);
+          if (resolvedSprite) {
+            resolved[pieceKey as Piece] = resolvedSprite;
+          }
+        } catch (error) {
+          console.warn(
+            `[NeoChessBoard] Failed to load sprite for piece "${pieceKey}".`,
+            error,
+          );
+        }
+      }),
+    );
+
+    if (token !== this._pieceSetToken) {
+      return;
+    }
+
+    this.customPieceSprites = resolved;
     this.renderAll();
   }
 
@@ -456,6 +542,65 @@ export class NeoChessBoard {
       }
   }
 
+  private async _resolvePieceSprite(
+    sprite: PieceSpriteSource | PieceSprite,
+    defaultScale: number,
+  ): Promise<ResolvedPieceSprite | null> {
+    const config: PieceSprite =
+      typeof sprite === 'object' && sprite !== null && 'image' in (sprite as PieceSprite)
+        ? (sprite as PieceSprite)
+        : ({ image: sprite } as PieceSprite);
+
+    let source: CanvasImageSource | null = null;
+    if (typeof config.image === 'string') {
+      source = await this._loadImage(config.image);
+    } else if (config.image) {
+      source = config.image;
+    }
+
+    if (!source) {
+      return null;
+    }
+
+    return {
+      image: source,
+      scale: config.scale ?? defaultScale ?? 1,
+      offsetX: config.offsetX ?? 0,
+      offsetY: config.offsetY ?? 0,
+    };
+  }
+
+  private _loadImage(src: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const doc = this.root?.ownerDocument ?? (typeof document !== 'undefined' ? document : null);
+      const img =
+        typeof Image !== 'undefined'
+          ? new Image()
+          : doc
+            ? (doc.createElement('img') as HTMLImageElement)
+            : null;
+
+      if (!img) {
+        reject(new Error('Image loading is not supported in the current environment.'));
+        return;
+      }
+
+      if (!src.startsWith('data:')) {
+        img.crossOrigin = 'anonymous';
+      }
+
+      try {
+        img.decoding = 'async';
+      } catch (e) {
+        // Ignore browsers that do not support decoding
+      }
+
+      img.onload = () => resolve(img);
+      img.onerror = (err) => reject(err instanceof Error ? err : new Error(String(err)));
+      img.src = src;
+    });
+  }
+
   /**
    * Draws a single piece sprite onto the pieces canvas.
    * @param piece The FEN notation of the piece (e.g., 'p', 'K').
@@ -464,6 +609,16 @@ export class NeoChessBoard {
    * @param scale Optional scale factor for the piece (default is 1).
    */
   private _drawPieceSprite(piece: string, x: number, y: number, scale = 1) {
+    const custom = this.customPieceSprites[piece as Piece];
+    if (custom) {
+      const spriteScale = scale * (custom.scale ?? 1);
+      const size = this.square * spriteScale;
+      const dx = x + (this.square - size) / 2 + custom.offsetX * this.square;
+      const dy = y + (this.square - size) / 2 + custom.offsetY * this.square;
+      this.ctxP.drawImage(custom.image, dx, dy, size, size);
+      return;
+    }
+
     // Map piece characters to their index in the sprite sheet.
     const map: any = { k: 0, q: 1, r: 2, b: 3, n: 4, p: 5 };
     const isW = isWhitePiece(piece);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -79,7 +79,14 @@ export interface Theme {
   squareNameColor: string;
 }
 
-export type PieceSpriteSource = string | CanvasImageSource;
+export type PieceSpriteImage =
+  | HTMLImageElement
+  | HTMLCanvasElement
+  | HTMLVideoElement
+  | ImageBitmap
+  | OffscreenCanvas;
+
+export type PieceSpriteSource = string | PieceSpriteImage;
 
 export interface PieceSprite {
   image: PieceSpriteSource;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -79,11 +79,28 @@ export interface Theme {
   squareNameColor: string;
 }
 
+export type PieceSpriteSource = string | CanvasImageSource;
+
+export interface PieceSprite {
+  image: PieceSpriteSource;
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
+}
+
+export type PieceSprites = Partial<Record<Piece, PieceSpriteSource | PieceSprite>>;
+
+export interface PieceSet {
+  pieces: PieceSprites;
+  defaultScale?: number;
+}
+
 export interface BoardOptions {
   size?: number;
   orientation?: 'white' | 'black';
   interactive?: boolean;
   theme?: ThemeName | Theme;
+  pieceSet?: PieceSet;
   showCoordinates?: boolean;
   animationMs?: number;
   highlightLegal?: boolean;

--- a/src/react/NeoChessBoard.tsx
+++ b/src/react/NeoChessBoard.tsx
@@ -45,6 +45,9 @@ export const NeoChessBoard = forwardRef<NeoChessRef, NeoChessProps>(
             boardRef.current.applyTheme(opts.theme);
           }
         }
+        if ('pieceSet' in opts) {
+          void boardRef.current.setPieceSet(opts.pieceSet);
+        }
         if (opts.soundEnabled !== undefined) {
           boardRef.current.setSoundEnabled(opts.soundEnabled);
         }

--- a/tests/core/NeoChessBoard.test.ts
+++ b/tests/core/NeoChessBoard.test.ts
@@ -185,6 +185,45 @@ describe('NeoChessBoard Core', () => {
     });
   });
 
+  describe('Custom piece sets', () => {
+    it('should draw custom sprites when a piece set is provided', async () => {
+      const ctx = (board as any).ctxP;
+      const drawImageMock = ctx.drawImage as jest.Mock;
+      drawImageMock.mockClear();
+
+      const customCanvas = document.createElement('canvas');
+
+      await board.setPieceSet({
+        pieces: {
+          P: { image: customCanvas },
+        },
+      });
+
+      const usedCustomSprite = drawImageMock.mock.calls.some((call) => call[0] === customCanvas);
+      expect(usedCustomSprite).toBe(true);
+    });
+
+    it('should revert to default sprites when the piece set is cleared', async () => {
+      const ctx = (board as any).ctxP;
+      const drawImageMock = ctx.drawImage as jest.Mock;
+      const customCanvas = document.createElement('canvas');
+
+      await board.setPieceSet({
+        pieces: {
+          P: { image: customCanvas },
+        },
+      });
+
+      drawImageMock.mockClear();
+
+      await board.setPieceSet(undefined);
+
+      const spriteSheet = (board as any).sprites.getSheet();
+      const usedDefaultSprite = drawImageMock.mock.calls.some((call) => call[0] === spriteSheet);
+      expect(usedDefaultSprite).toBe(true);
+    });
+  });
+
   describe('Cleanup', () => {
     it('should have destroy method for cleanup', () => {
       expect(typeof board.destroy).toBe('function');


### PR DESCRIPTION
## Summary
- add a `pieceSet` option and supporting types so consumers can supply their own sprites
- load and render custom pieces within `NeoChessBoard`, with a public `setPieceSet` helper and React bindings
- document the new capability and cover it with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cabd82f6a0832798ed887c3eca5b7a