### PR TITLE
Add board auto-flip option and fix coordinate layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release preparation
 - Comprehensive test suite
 - Documentation and examples
+- Auto-flip option to keep the active side at the bottom of the board
+- Square coordinates now remain anchored to the bottom and left edges regardless of orientation
 
 ## [0.1.0] - 2024-12-31
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _Perfect for creating chess applications with Chessbook-like feel and performanc
 - 🧩 Bring your own piece set (SVG, PNG, or Canvas sources)
 - ✨ Fluid animations and transitions
 - 🎯 Legal move highlighting
+- 🔄 Optional auto-flip to follow the side to move
 - 📱 Responsive design
 
 🔧 **Developer Friendly**
@@ -52,6 +53,7 @@ _Perfect for creating chess applications with Chessbook-like feel and performanc
 - 🔄 FEN support
 - 🎮 Custom rules engine
 - 🏹 Visual PGN Annotations (arrows & circles)
+- 📐 Square names stay aligned to the bottom and left edges in every orientation
 
 ## 🚀 Quick Start
 
@@ -191,6 +193,7 @@ interface NeoChessProps {
   theme?: ThemeName | Theme; // Built-in theme name or custom object
   pieceSet?: PieceSet; // Provide custom piece sprites
   orientation?: 'white' | 'black'; // Board orientation
+  autoFlip?: boolean; // Follow the side to move automatically
   interactive?: boolean; // Enable drag & drop
   showCoordinates?: boolean; // Show file/rank labels
   animationMs?: number; // Animation duration
@@ -410,7 +413,8 @@ interface NeoChessProps {
   // Visual Appearance
   theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board flip
-  showCoordinates?: boolean; // A-H, 1-8 labels
+  autoFlip?: boolean; // Automatically follow the side to move
+  showCoordinates?: boolean; // A-H, 1-8 labels (always bottom/left)
 
   // Interaction
   interactive?: boolean; // Enable piece dragging

--- a/mkdocs_docs/api.md
+++ b/mkdocs_docs/api.md
@@ -62,6 +62,14 @@ Flip the board orientation.
 
 - `color: 'white' | 'black'` - Which color should be at the bottom
 
+##### `setAutoFlip(enabled: boolean): void`
+
+Enable or disable automatic board flipping based on the side to move.
+
+**Parameters:**
+
+- `enabled: boolean` - `true` to follow the active player, `false` to keep the current orientation
+
 ##### `reset(): void`
 
 Reset the board to the initial chess position.
@@ -476,15 +484,30 @@ function App() {
 
 ```typescript
 interface BoardOptions {
-  theme: ThemeName | Theme;
-  orientation: 'white' | 'black';
-  draggable: boolean;
-  showCoordinates: boolean;
-  animationDuration: number;
-  highlightLastMove: boolean;
-  highlightLegalMoves: boolean;
+  size?: number;
+  orientation?: 'white' | 'black';
+  interactive?: boolean;
+  theme?: ThemeName | Theme;
+  pieceSet?: PieceSet;
+  showCoordinates?: boolean;
+  animationMs?: number;
+  highlightLegal?: boolean;
+  fen?: string;
+  rulesAdapter?: RulesAdapter;
+  allowPremoves?: boolean;
+  showArrows?: boolean;
+  showHighlights?: boolean;
+  rightClickHighlights?: boolean;
+  maxArrows?: number;
+  maxHighlights?: number;
+  soundEnabled?: boolean;
+  showSquareNames?: boolean;
+  autoFlip?: boolean;
+  soundUrl?: string;
 }
 ```
+
+> **Note:** When `showSquareNames` is enabled, the file letters and rank numbers remain on the bottom and left edges even when the board flips orientation, mirroring the behaviour of chess.com.
 
 ### Theme
 

--- a/mkdocs_docs/index.md
+++ b/mkdocs_docs/index.md
@@ -34,6 +34,7 @@ _Perfect for creating chess applications with Chessbook-like feel and performanc
 - 🎨 Beautiful piece sprites with shadows
 - ✨ Fluid animations and transitions
 - 🎯 Legal move highlighting
+- 🔄 Optional auto-flip to follow the side to move
 - 📱 Responsive design
 
 🔧 **Developer Friendly**
@@ -51,6 +52,7 @@ _Perfect for creating chess applications with Chessbook-like feel and performanc
 - 🔄 FEN support
 - 🎮 Custom rules engine
 - 🏹 Visual PGN Annotations (arrows & circles)
+- 📐 Square names stay aligned to the bottom and left edges in every orientation
 
 ## 🚀 Quick Start
 
@@ -383,7 +385,8 @@ interface NeoChessProps {
   // Visual Appearance
   theme?: ThemeName | Theme; // Built-in theme name or custom object
   orientation?: 'white' | 'black'; // Board flip
-  showCoordinates?: boolean; // A-H, 1-8 labels
+  autoFlip?: boolean; // Automatically follow the side to move
+  showCoordinates?: boolean; // A-H, 1-8 labels (always bottom/left)
 
   // Interaction
   interactive?: boolean; // Enable piece dragging

--- a/src/core/DrawingManager.ts
+++ b/src/core/DrawingManager.ts
@@ -326,51 +326,42 @@ export class DrawingManager {
     ctx.scale(dpr, dpr);
 
     const squareSize = this.squareSize / dpr;
-    const fontSize = Math.max(10, squareSize * 0.18); // Slightly reduced font size
-    const filePadding = squareSize * 0.1;
-    const rankPadding = squareSize * 0.15;
+    const boardHeight = this.canvas.height / dpr;
+    const fontSize = Math.max(10, squareSize * 0.18);
+    const filePadding = squareSize * 0.12;
+    const rankPadding = squareSize * 0.12;
 
-    // More subtle font style
     ctx.font = `500 ${fontSize}px 'Segoe UI', Arial, sans-serif`;
-    ctx.textBaseline = 'middle';
 
-    // More subtle colors with opacity
     const lightSquareColor = 'rgba(240, 217, 181, 0.7)';
     const darkSquareColor = 'rgba(181, 136, 99, 0.7)';
 
-    // Draw column letters (a-h)
-    for (let file = 0; file < 8; file++) {
-      const char = String.fromCharCode(97 + file); // a-h
-      const x =
-        (orientation === 'white' ? file : 7 - file) * squareSize +
-        (orientation === 'white' ? filePadding : squareSize - filePadding);
-      const y =
-        orientation === 'white'
-          ? this.canvas.height / dpr - filePadding
-          : filePadding + fontSize / 2;
+    const bottomRankIndex = orientation === 'white' ? 0 : 7;
+    const leftFileIndex = orientation === 'white' ? 0 : 7;
 
-      // Use the correct color based on orientation and square
-      const isLightSquare = (file + (orientation === 'white' ? 7 : 0)) % 2 === 1;
+    // Draw file letters along the bottom edge
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'alphabetic';
+    for (let column = 0; column < 8; column++) {
+      const boardFileIndex = orientation === 'white' ? column : 7 - column;
+      const char = String.fromCharCode(97 + boardFileIndex);
+      const x = column * squareSize + filePadding;
+      const y = boardHeight - filePadding;
+      const isLightSquare = (boardFileIndex + bottomRankIndex) % 2 === 0;
       ctx.fillStyle = isLightSquare ? lightSquareColor : darkSquareColor;
-
-      ctx.textAlign = 'left'; // Always left for file labels
       ctx.fillText(char, x, y);
     }
 
-    // Draw rank numbers (1-8)
-    for (let rank = 0; rank < 8; rank++) {
-      const num = 8 - rank;
-      const x = orientation === 'white' ? rankPadding : this.canvas.width / dpr - rankPadding;
-      const y =
-        (orientation === 'white' ? rank : 7 - rank) * squareSize +
-        (orientation === 'white' ? squareSize - rankPadding : rankPadding + fontSize / 2);
-
-      // Use the correct color based on orientation and square
-      const isLightSquare = (rank + (orientation === 'white' ? 1 : 0)) % 2 === 0;
+    // Draw rank numbers along the left edge
+    ctx.textBaseline = 'middle';
+    for (let row = 0; row < 8; row++) {
+      const boardRankIndex = orientation === 'white' ? row : 7 - row;
+      const label = (boardRankIndex + 1).toString();
+      const x = rankPadding;
+      const y = boardHeight - (row + 0.5) * squareSize;
+      const isLightSquare = (leftFileIndex + boardRankIndex) % 2 === 0;
       ctx.fillStyle = isLightSquare ? lightSquareColor : darkSquareColor;
-
-      ctx.textAlign = 'left'; // Always left for rank labels
-      ctx.fillText(num.toString(), x, y);
+      ctx.fillText(label, x, y);
     }
 
     ctx.restore();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -122,6 +122,7 @@ export interface BoardOptions {
   maxHighlights?: number;
   soundEnabled?: boolean;
   showSquareNames?: boolean;
+  autoFlip?: boolean;
   soundUrl?: string;
 }
 

--- a/src/react/NeoChessBoard.tsx
+++ b/src/react/NeoChessBoard.tsx
@@ -52,6 +52,9 @@ export const NeoChessBoard = forwardRef<NeoChessRef, NeoChessProps>(
         if (opts.soundEnabled !== undefined) {
           boardRef.current.setSoundEnabled(opts.soundEnabled);
         }
+        if (opts.autoFlip !== undefined) {
+          boardRef.current.setAutoFlip(opts.autoFlip);
+        }
         if (opts.orientation !== undefined) {
           boardRef.current.setOrientation(opts.orientation);
         }

--- a/tests/core/DrawingManager.test.ts
+++ b/tests/core/DrawingManager.test.ts
@@ -432,6 +432,42 @@ describe('DrawingManager', () => {
       expect(mockContext.restore).toHaveBeenCalled();
     });
 
+    it('should place coordinate labels along the bottom and left for white orientation', () => {
+      drawingManager.setShowSquareNames(true);
+      mockContext.fillText.mockClear();
+
+      drawingManager.renderSquareNames('white', 0, 1);
+
+      expect(mockContext.fillText).toHaveBeenCalledTimes(16);
+      const [fileChar, fileX, fileY] = mockContext.fillText.mock.calls[0];
+      expect(fileChar).toBe('a');
+      expect(fileX).toBeCloseTo(6, 5);
+      expect(fileY).toBeCloseTo(394, 5);
+
+      const [rankChar, rankX, rankY] = mockContext.fillText.mock.calls[8];
+      expect(rankChar).toBe('1');
+      expect(rankX).toBeCloseTo(6, 5);
+      expect(rankY).toBeCloseTo(375, 5);
+    });
+
+    it('should keep coordinate labels on the bottom and left when black is at the bottom', () => {
+      drawingManager.setShowSquareNames(true);
+      mockContext.fillText.mockClear();
+
+      drawingManager.renderSquareNames('black', 0, 1);
+
+      expect(mockContext.fillText).toHaveBeenCalledTimes(16);
+      const [fileChar, fileX, fileY] = mockContext.fillText.mock.calls[0];
+      expect(fileChar).toBe('h');
+      expect(fileX).toBeCloseTo(6, 5);
+      expect(fileY).toBeCloseTo(394, 5);
+
+      const [rankChar, rankX, rankY] = mockContext.fillText.mock.calls[8];
+      expect(rankChar).toBe('8');
+      expect(rankX).toBeCloseTo(6, 5);
+      expect(rankY).toBeCloseTo(375, 5);
+    });
+
     it('should complete draw cycle', () => {
       drawingManager.draw(mockContext);
 

--- a/tests/core/NeoChessBoard.test.ts
+++ b/tests/core/NeoChessBoard.test.ts
@@ -178,6 +178,29 @@ describe('NeoChessBoard Core', () => {
       }).not.toThrow();
     });
 
+    it('should follow side to move when autoFlip is enabled', () => {
+      const autoBoard = new NeoChessBoard(container, { autoFlip: true });
+      expect((autoBoard as any).orientation).toBe('white');
+
+      const blackTurnFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1';
+      autoBoard.setFEN(blackTurnFen, true);
+
+      expect((autoBoard as any).orientation).toBe('black');
+      autoBoard.destroy();
+    });
+
+    it('should update orientation immediately when enabling autoFlip later', () => {
+      const manualBoard = new NeoChessBoard(container, { orientation: 'white' });
+      const blackTurnFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1';
+
+      manualBoard.setFEN(blackTurnFen, true);
+      expect((manualBoard as any).orientation).toBe('white');
+
+      manualBoard.setAutoFlip(true);
+      expect((manualBoard as any).orientation).toBe('black');
+      manualBoard.destroy();
+    });
+
     it('should accept interactive configuration', () => {
       expect(() => {
         new NeoChessBoard(container, { interactive: false });

--- a/tests/react/NeoChessBoard.test.tsx
+++ b/tests/react/NeoChessBoard.test.tsx
@@ -14,6 +14,7 @@ const mockBoard = {
   setTheme: jest.fn(),
   applyTheme: jest.fn(),
   setSoundEnabled: jest.fn(),
+  setAutoFlip: jest.fn(),
   setOrientation: jest.fn(),
   setShowArrows: jest.fn(),
   setShowHighlights: jest.fn(),
@@ -86,6 +87,7 @@ describe('NeoChessBoard React Component', () => {
         showCoordinates: true,
         animationMs: 200,
         highlightLegal: false,
+        autoFlip: true,
       };
 
       render(<NeoChessBoard {...options} />);
@@ -208,11 +210,13 @@ describe('NeoChessBoard React Component', () => {
           allowPremoves={false}
           highlightLegal={false}
           showSquareNames={false}
+          autoFlip={false}
         />,
       );
 
       [
         mockBoard.setSoundEnabled,
+        mockBoard.setAutoFlip,
         mockBoard.setOrientation,
         mockBoard.setShowArrows,
         mockBoard.setShowHighlights,
@@ -230,10 +234,12 @@ describe('NeoChessBoard React Component', () => {
           allowPremoves
           highlightLegal
           showSquareNames
+          autoFlip
         />,
       );
 
       expect(mockBoard.setSoundEnabled).toHaveBeenCalledWith(true);
+      expect(mockBoard.setAutoFlip).toHaveBeenCalledWith(true);
       expect(mockBoard.setOrientation).toHaveBeenCalledWith('black');
       expect(mockBoard.setShowArrows).toHaveBeenCalledWith(true);
       expect(mockBoard.setShowHighlights).toHaveBeenCalledWith(true);


### PR DESCRIPTION
## Summary
- add an `autoFlip` option to the core board, expose `setAutoFlip`, and propagate the feature through the React wrapper with updated docs
- keep file/rank labels anchored to the bottom-left regardless of orientation and add regression tests for the new layout
- expose auto-flip controls in the demo, keep the orientation label in sync, and refresh the README/mkdocs with the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf1d12e948327841c4bda5848edd3