### PR TITLE
Improve theme creator layout scrolling

### DIFF
--- a/demo/App.module.css
+++ b/demo/App.module.css
@@ -1257,6 +1257,26 @@ body {
   padding: 32px;
   max-width: 1400px;
   margin: 0 auto;
+  min-height: calc(100vh - 64px);
+  align-items: flex-start;
+}
+
+.creatorControls {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.creatorPreview {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: sticky;
+  top: 32px;
+  align-self: flex-start;
 }
 
 @media (max-width: 1200px) {
@@ -1264,19 +1284,21 @@ body {
     grid-template-columns: 1fr;
     gap: 24px;
     padding: 24px;
+    min-height: auto;
+    align-items: stretch;
   }
-}
 
-.creatorControls {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
+  .creatorControls {
+    max-height: none;
+    overflow-y: visible;
+    padding-right: 0;
+  }
 
-.creatorPreview {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+  .creatorPreview {
+    position: static;
+    top: auto;
+    align-self: stretch;
+  }
 }
 
 .controlSection {


### PR DESCRIPTION
## Summary
- ensure the theme creator layout stretches to the viewport height and aligns its columns to support sticky behavior
- limit the creator controls column height, add scrolling, and keep the preview column sticky with consistent padding
- relax the scrolling and sticky constraints on narrow screens to avoid double scrollbars while preserving responsiveness

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test:e2e *(fails: missing script)*
- Verified theme-creator layout manually in `demo/theme-creator.html` via Vite dev server


------
https://chatgpt.com/codex/tasks/task_e_68cb0cb6a2cc83279f9e0ce079c3683f