### PR TITLE
Add NeoChessBoard feature toggle coverage

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,6 +34,8 @@ global.HTMLCanvasElement.prototype.getContext = jest.fn((contextId: string) => {
       fill: jest.fn(),
       stroke: jest.fn(),
       drawImage: jest.fn(),
+      fillText: jest.fn(),
+      measureText: jest.fn(() => ({ width: 0 })),
       createLinearGradient: jest.fn(() => ({ addColorStop: jest.fn() })),
       save: jest.fn(),
       restore: jest.fn(),


### PR DESCRIPTION
## Summary
- add comprehensive NeoChessBoard unit tests that cover sound toggles, drawing manager integration and export helpers
- extend the shared canvas mock to support text rendering APIs used by the new tests

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb175ed8a88327b5be72e7a1052b52