### PR TITLE
feat: expose attacked square detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,14 @@ const pgnWithAnnotations = rules.toPgn(true);
 console.log(pgnWithAnnotations);
 ```
 
+#### Détection des cases attaquées
+
+`ChessJsRules` s'appuie directement sur `chess.js` pour analyser le contrôle des cases :
+
+- `getAttackedSquares()` retourne toutes les cases actuellement menacées par le joueur au trait, idéal pour mettre à jour un surlignage dynamique.
+- `isSquareAttacked(square, by?)` vérifie si une case donnée est attaquée par la couleur spécifiée (ou par le joueur au trait par défaut). La méthode valide la case fournie (notation algébrique) et accepte des entrées insensibles à la casse.
+
+
 ## 🏗️ Architecture
 
 ```

--- a/src/core/ChessJsRules.ts
+++ b/src/core/ChessJsRules.ts
@@ -1,4 +1,4 @@
-import { Chess } from 'chess.js';
+import { Chess, SQUARES, type Color } from 'chess.js';
 import type { RulesAdapter, Move } from './types';
 import { PgnNotation, PgnMetadata } from './PgnNotation';
 
@@ -205,18 +205,45 @@ export class ChessJsRules implements RulesAdapter {
 
   /**
    * Obtenir les cases attaquées par le joueur actuel
+   *
+   * Utilise la détection native de chess.js pour identifier toutes les cases
+   * actuellement contrôlées par le joueur au trait.
    */
   getAttackedSquares(): string[] {
-    // Méthode simplifiée - retourne un tableau vide pour éviter les problèmes de types
-    return [];
+    const attackingColor: Color = this.chess.turn();
+
+    return SQUARES.filter((square) => this.chess.isAttacked(square, attackingColor)).map(
+      (square) => square,
+    );
   }
 
   /**
    * Vérifier si une case est attaquée
+   *
+   * @param square Case à vérifier (notation algébrique, insensible à la casse)
+   * @param by Couleur optionnelle pour vérifier une couleur spécifique
+   * @throws {Error} si la case ou la couleur fournie est invalide
    */
   isSquareAttacked(square: string, by?: 'w' | 'b'): boolean {
-    // Méthode simplifiée - retourne false pour éviter les problèmes de types
-    return false;
+    if (typeof square !== 'string') {
+      throw new Error(`Invalid square: ${square}`);
+    }
+
+    const normalizedSquare = square.toLowerCase();
+    if (!(SQUARES as readonly string[]).includes(normalizedSquare)) {
+      throw new Error(`Invalid square: ${square}`);
+    }
+
+    let colorToCheck: Color;
+    if (by === undefined) {
+      colorToCheck = this.chess.turn();
+    } else if (by === 'w' || by === 'b') {
+      colorToCheck = by;
+    } else {
+      throw new Error(`Invalid color: ${by}`);
+    }
+
+    return this.chess.isAttacked(normalizedSquare as (typeof SQUARES)[number], colorToCheck);
   }
 
   /**

--- a/tests/core/ChessJsRules.test.ts
+++ b/tests/core/ChessJsRules.test.ts
@@ -374,15 +374,26 @@ describe('ChessJsRules', () => {
 
   describe('Additional Methods', () => {
     test('should get attacked squares', () => {
+      rules.setFEN('4k3/8/3n4/8/4N3/8/8/4K3 w - - 0 1');
+
       const attackedSquares = rules.getAttackedSquares();
-      expect(Array.isArray(attackedSquares)).toBe(true);
-      expect(attackedSquares.length).toBe(0); // Simplified implementation returns empty array
+      const expectedSquares = ['d6', 'f6', 'c5', 'g5', 'c3', 'g3', 'd2', 'e2', 'f2', 'd1', 'f1'];
+
+      expect(attackedSquares).toHaveLength(expectedSquares.length);
+      expect(attackedSquares).toEqual(expect.arrayContaining(expectedSquares));
     });
 
     test('should check if square is attacked', () => {
-      const isAttacked = rules.isSquareAttacked('e4');
-      expect(typeof isAttacked).toBe('boolean');
-      expect(isAttacked).toBe(false); // Simplified implementation returns false
+      rules.setFEN('4k3/8/3n4/8/4N3/8/8/4K3 w - - 0 1');
+
+      expect(rules.isSquareAttacked('d6')).toBe(true);
+      expect(rules.isSquareAttacked('e4')).toBe(false);
+      expect(rules.isSquareAttacked('e4', 'b')).toBe(true);
+      expect(rules.isSquareAttacked('D6')).toBe(true); // Case insensitive input
+    });
+
+    test('should reject invalid squares when checking attacks', () => {
+      expect(() => rules.isSquareAttacked('z9')).toThrow('Invalid square');
     });
 
     test('should get half moves', () => {


### PR DESCRIPTION
## Summary
- leverage chess.js attackers API to list attacked squares and validate square checks
- cover the new behaviour with dedicated unit tests
- document the helper methods in the README

## Testing
- npm run lint
- npm run test -- tests/core/ChessJsRules.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb55c59e208327a2d8081605441cd3