### PR TITLE
Improve demo board responsiveness

### DIFF
--- a/demo/App.module.css
+++ b/demo/App.module.css
@@ -186,10 +186,11 @@ body {
   min-height: 100vh;
   background: var(--bg-primary);
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) 380px;
-  gap: var(--spacing-lg);
+  width: 100%;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  column-gap: var(--spacing-lg);
+  row-gap: var(--spacing-lg);
   padding: var(--spacing-xl);
-  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -359,6 +360,12 @@ body {
     inset 0 1px 0 var(--glass-highlight);
   position: relative;
   overflow: hidden;
+}
+
+.boardCanvas {
+  width: 100%;
+  max-width: clamp(260px, 100%, 720px);
+  aspect-ratio: 1 / 1;
 }
 
 .boardWrapper::before {

--- a/demo/App.module.css.d.ts
+++ b/demo/App.module.css.d.ts
@@ -31,6 +31,7 @@ declare const styles: {
   readonly '4': string;
   readonly themeCreatorLink: string;
   readonly boardWrapper: string;
+  readonly boardCanvas: string;
   readonly controlsSection: string;
   readonly panel: string;
   readonly panelHeader: string;

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -406,7 +406,7 @@ export const App: React.FC = () => {
               syncOrientationWithFen(nextFen);
               updateStatusSnapshot();
             }}
-            style={{ width: 'min(90vmin,720px)', aspectRatio: '1/1' }}
+            className={styles.boardCanvas}
             showSquareNames={boardOptions.showSquareNames}
             showArrows={boardOptions.showArrows}
             showHighlights={boardOptions.showHighlights}


### PR DESCRIPTION
## Summary
- update the demo layout container to use a full-width, fluid grid
- add a reusable board canvas class that enforces a square responsive board
- apply the new styling to the NeoChessBoard instance in the demo

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3189462c8327937f6d6fd6e7cb1d