### PR TITLE
Refine demo board options with glassmorphism styling

### DIFF
--- a/demo/App.module.css
+++ b/demo/App.module.css
@@ -1,36 +1,5 @@
 /* ===== DESIGN FLAT MINIMALISTE MODERN ===== */
 
-/* Options Grid */
-.optionGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-md);
-}
-
-.optionButton {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius);
-  padding: var(--spacing-sm);
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  text-align: center;
-}
-
-.optionButton:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-medium);
-}
-
-.optionActive {
-  background: var(--accent-primary-light);
-  border-color: var(--accent-primary);
-  color: var(--accent-primary-dark);
-  font-weight: 500;
-}
-
 /* Variables CSS - Design System Minimaliste */
 :root {
   /* Couleurs principales - palette neutre moderne */
@@ -90,6 +59,21 @@
   --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   --shadow-focus: 0 0 0 3px rgba(99, 102, 241, 0.1);
+
+  /* Palette verre dépoli */
+  --accent-color: #4f46e5;
+  --accent-hover: #6366f1;
+  --accent-glass: rgba(99, 102, 241, 0.22);
+  --glass-bg: rgba(15, 23, 42, 0.58);
+  --glass-hover: rgba(30, 41, 59, 0.68);
+  --glass-active: rgba(99, 102, 241, 0.22);
+  --glass-border: rgba(148, 163, 184, 0.28);
+  --glass-active-border: rgba(129, 140, 248, 0.65);
+  --glass-highlight: rgba(255, 255, 255, 0.16);
+  --glass-focus-ring: rgba(99, 102, 241, 0.45);
+  --blur-amount: 20px;
+  --blur-light: 12px;
+  --shadow-glass: 0 18px 38px rgba(15, 23, 42, 0.4);
 }
 
 /* Reset et base */
@@ -115,69 +99,190 @@ body {
 /* ===== OPTIONS DE L'ECHIQUIER ===== */
 .optionGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 12px;
-  margin-top: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
 }
 
 .optionButton {
-  padding: 10px 14px;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius);
-  background-color: var(--bg-card);
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: 14px 18px;
+  border-radius: calc(var(--radius) + 16px);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
   color: var(--text-primary);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease,
+    color 0.2s ease;
   text-align: left;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  min-height: 64px;
+  backdrop-filter: blur(var(--blur-light));
+  -webkit-backdrop-filter: blur(var(--blur-light));
   box-shadow: var(--shadow-sm);
 }
 
 .optionButton:hover {
-  background-color: var(--bg-hover);
+  background: var(--glass-hover);
+  border-color: var(--glass-active-border);
+  box-shadow: var(--shadow-glass);
   transform: translateY(-1px);
-  box-shadow: var(--shadow);
+}
+
+.optionButton:focus-visible {
+  outline: none;
+  border-color: var(--glass-active-border);
+  box-shadow:
+    var(--shadow-glass),
+    0 0 0 3px var(--glass-focus-ring);
+  transform: translateY(-1px);
 }
 
 .optionButton:active {
   transform: translateY(0);
+}
+
+.optionButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  background: rgba(15, 23, 42, 0.42);
+  border-color: rgba(148, 163, 184, 0.22);
   box-shadow: none;
+  transform: none;
 }
 
-.optionButton.optionActive {
-  background-color: var(--accent-primary-light);
-  border-color: var(--accent-primary);
-  color: var(--accent-primary-dark);
+.optionButton:disabled .optionLabel {
+  color: rgba(148, 163, 184, 0.75);
 }
 
-.optionButton svg {
-  font-size: 1.1em;
-}
-
-/* Style spécifique pour les boutons d'action */
-.optionButton.action {
-  background-color: var(--accent-primary);
+.optionButton.optionActive,
+.optionButton[aria-pressed='true'] {
+  background: var(--glass-active);
+  border-color: var(--glass-active-border);
+  box-shadow: var(--shadow-glass);
   color: white;
-  justify-content: center;
+}
+
+.optionIcon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.optionButton:hover .optionIcon {
+  color: var(--text-primary);
+  background: rgba(148, 163, 184, 0.22);
+  transform: scale(1.05);
+}
+
+.optionButton.optionActive .optionIcon,
+.optionButton[aria-pressed='true'] .optionIcon {
+  background: var(--accent-glass);
+  color: white;
+}
+
+.optionIcon svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+}
+
+.optionLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   font-weight: 600;
+  color: var(--text-primary);
+}
+
+.optionTitle {
+  font-size: 0.95rem;
+  line-height: 1.2;
+}
+
+.optionHint {
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.optionButton.optionActive .optionHint,
+.optionButton[aria-pressed='true'] .optionHint {
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.optionButton.optionActive .optionLabel,
+.optionButton[aria-pressed='true'] .optionLabel {
+  color: white;
+}
+
+.optionButton:disabled .optionIcon {
+  background: rgba(148, 163, 184, 0.1);
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.optionButton:disabled .optionHint {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.optionButton.action {
+  background: var(--accent-color);
+  border-color: transparent;
+  color: white;
+}
+
+.optionButton.action .optionIcon {
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
 }
 
 .optionButton.action:hover {
-  background-color: var(--accent-primary-hover);
+  background: var(--accent-hover);
+}
+
+.optionButton.action:hover .optionIcon {
+  background: rgba(255, 255, 255, 0.24);
 }
 
 .optionButton.danger {
-  background-color: var(--error-light);
-  color: var(--error-dark);
-  border-color: var(--error);
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.45);
+  color: #f87171;
+}
+
+.optionButton.danger .optionIcon {
+  background: rgba(239, 68, 68, 0.16);
+  color: #f87171;
 }
 
 .optionButton.danger:hover {
-  background-color: #fee2e2;
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #fecaca;
+}
+
+.optionButton.danger:hover .optionIcon {
+  background: rgba(248, 113, 113, 0.28);
+  color: #fee2e2;
 }
 
 /* ===== LAYOUT PRINCIPAL ===== */

--- a/demo/App.module.css.d.ts
+++ b/demo/App.module.css.d.ts
@@ -3,6 +3,10 @@
 declare const styles: {
   readonly optionGrid: string;
   readonly optionButton: string;
+  readonly optionIcon: string;
+  readonly optionLabel: string;
+  readonly optionTitle: string;
+  readonly optionHint: string;
   readonly '85rem': string;
   readonly '2s': string;
   readonly optionActive: string;

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -12,6 +12,119 @@ import {
   useLoadingState,
 } from './components/Loaders';
 
+const SvgIcon: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {children}
+  </svg>
+);
+
+const ArrowsIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M5 7h8" />
+    <path d="m13 7-2-2" />
+    <path d="m13 7-2 2" />
+    <path d="M19 17h-8" />
+    <path d="m11 17 2-2" />
+    <path d="m11 17 2 2" />
+  </SvgIcon>
+);
+
+const HighlightIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="m12 6.4 1.7 3.3 3.6.5-2.7 2.6.6 3.6L12 15.8l-3.2 1.6.6-3.6-2.7-2.6 3.6-.5z" />
+  </SvgIcon>
+);
+
+const PremovesIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="m6 8 4 4-4 4" />
+    <path d="m12 8 4 4-4 4" />
+  </SvgIcon>
+);
+
+const SquareNamesIcon: React.FC = () => (
+  <SvgIcon>
+    <rect x={4.5} y={4.5} width={15} height={15} rx={2} />
+    <path d="M9.5 4.5v15" />
+    <path d="M14.5 4.5v15" />
+    <path d="M4.5 9.5h15" />
+    <path d="M4.5 14.5h15" />
+  </SvgIcon>
+);
+
+const SoundIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M5.5 10v4h2.8L12 15.7V8.3L8.3 10z" />
+    <path d="M15 9.5a2.5 2.5 0 0 1 0 5" />
+    <path d="M17.5 8a5 5 0 0 1 0 8" />
+  </SvgIcon>
+);
+
+const LegalMovesIcon: React.FC = () => (
+  <SvgIcon>
+    <circle cx={12} cy={12} r={6} />
+    <circle cx={12} cy={12} r={2.6} />
+    <path d="M12 6v2" />
+    <path d="M12 16v2" />
+    <path d="M6 12h2" />
+    <path d="M16 12h2" />
+  </SvgIcon>
+);
+
+const AutoFlipIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M8 7a6 6 0 0 1 9 2" />
+    <path d="M17 5v4h-4" />
+    <path d="M16 17a6 6 0 0 1-9-2" />
+    <path d="M7 19v-4h4" />
+  </SvgIcon>
+);
+
+const OrientationIcon: React.FC = () => (
+  <SvgIcon>
+    <rect x={4.5} y={4.5} width={15} height={15} rx={2} />
+    <path d="m9 9 3 3-3 3" />
+    <path d="m15 9-3 3 3 3" />
+  </SvgIcon>
+);
+
+const AddArrowIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M5 16h8" />
+    <path d="m13 16-2-2" />
+    <path d="m13 16-2 2" />
+    <path d="M17 7v4" />
+    <path d="M15 9h4" />
+  </SvgIcon>
+);
+
+const AddHighlightIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="m12 6.4 1.7 3.3 3.6.5-2.7 2.6.6 3.6L12 15.8l-3.2 1.6.6-3.6-2.7-2.6 3.6-.5z" />
+    <path d="M19 6v4" />
+    <path d="M17 8h4" />
+  </SvgIcon>
+);
+
+const TrashIcon: React.FC = () => (
+  <SvgIcon>
+    <path d="M10 5h4" />
+    <path d="M6 7h12" />
+    <path d="M9 7v10a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1V7" />
+    <path d="M10.5 11v6" />
+    <path d="M13.5 11v6" />
+  </SvgIcon>
+);
+
 const buildStatusSnapshot = (rules: ChessJsRules) => ({
   moveNumber: rules.moveNumber(),
   turn: rules.turn(),
@@ -470,55 +583,126 @@ export const App: React.FC = () => {
           <div className={styles.panelContent}>
             <div className={styles.optionGrid}>
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.showArrows ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('showArrows')}
+                aria-pressed={boardOptions.showArrows}
               >
-                {boardOptions.showArrows ? '✅' : '❌'} Flèches
+                <span className={styles.optionIcon}>
+                  <ArrowsIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Flèches interactives</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.showArrows ? 'Activées' : 'Masquées'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.showHighlights ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('showHighlights')}
+                aria-pressed={boardOptions.showHighlights}
               >
-                {boardOptions.showHighlights ? '✅' : '❌'} Surbrillances
+                <span className={styles.optionIcon}>
+                  <HighlightIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Surbrillances</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.showHighlights ? 'Visibles' : 'Masquées'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.allowPremoves ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('allowPremoves')}
+                aria-pressed={boardOptions.allowPremoves}
               >
-                {boardOptions.allowPremoves ? '✅' : '❌'} Pré-mouvements
+                <span className={styles.optionIcon}>
+                  <PremovesIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Pré-mouvements</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.allowPremoves ? 'Autorisés' : 'Bloqués'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.showSquareNames ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('showSquareNames')}
+                aria-pressed={boardOptions.showSquareNames}
               >
-                {boardOptions.showSquareNames ? '✅' : '❌'} Noms des cases
+                <span className={styles.optionIcon}>
+                  <SquareNamesIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Coordonnées</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.showSquareNames ? 'Affichées' : 'Masquées'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.soundEnabled ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('soundEnabled')}
+                aria-pressed={boardOptions.soundEnabled}
               >
-                {boardOptions.soundEnabled ? '🔊' : '🔇'} Sons
+                <span className={styles.optionIcon}>
+                  <SoundIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Effets sonores</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.soundEnabled ? 'Actifs' : 'Coupés'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.highlightLegal ? styles.optionActive : ''}`}
                 onClick={() => toggleOption('highlightLegal')}
+                aria-pressed={boardOptions.highlightLegal}
               >
-                {boardOptions.highlightLegal ? '✅' : '❌'} Surbrillance légale
+                <span className={styles.optionIcon}>
+                  <LegalMovesIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Coups légaux</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.highlightLegal ? 'Signalés' : 'Masqués'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={`${styles.optionButton} ${boardOptions.autoFlip ? styles.optionActive : ''}`}
                 onClick={toggleAutoFlip}
+                aria-pressed={boardOptions.autoFlip}
               >
-                {boardOptions.autoFlip ? '✅' : '❌'} Auto flip
+                <span className={styles.optionIcon}>
+                  <AutoFlipIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Auto-flip</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.autoFlip ? 'Synchronisé' : 'Manuel'}
+                  </span>
+                </span>
               </button>
 
               <button
+                type="button"
                 className={styles.optionButton}
                 onClick={toggleOrientation}
                 disabled={boardOptions.autoFlip}
@@ -528,23 +712,51 @@ export const App: React.FC = () => {
                     : undefined
                 }
               >
-                🔄 Orientation: {boardOptions.orientation === 'white' ? 'Blanc' : 'Noir'}
+                <span className={styles.optionIcon}>
+                  <OrientationIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Orientation</span>
+                  <span className={styles.optionHint}>
+                    {boardOptions.autoFlip
+                      ? 'Contrôlée automatiquement'
+                      : `Vue ${boardOptions.orientation === 'white' ? 'Blancs' : 'Noirs'}`}
+                  </span>
+                </span>
               </button>
 
-              <button className={styles.optionButton} onClick={addRandomArrow}>
-                🎯 Ajouter une flèche aléatoire
+              <button type="button" className={styles.optionButton} onClick={addRandomArrow}>
+                <span className={styles.optionIcon}>
+                  <AddArrowIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Ajouter une flèche</span>
+                  <span className={styles.optionHint}>Placement aléatoire</span>
+                </span>
               </button>
 
-              <button className={styles.optionButton} onClick={addRandomHighlight}>
-                ✨ Ajouter une surbrillance
+              <button type="button" className={styles.optionButton} onClick={addRandomHighlight}>
+                <span className={styles.optionIcon}>
+                  <AddHighlightIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Ajouter une zone</span>
+                  <span className={styles.optionHint}>Surbrillance aléatoire</span>
+                </span>
               </button>
 
               <button
-                className={styles.optionButton}
+                type="button"
+                className={`${styles.optionButton} ${styles.danger}`}
                 onClick={clearAll}
-                style={{ backgroundColor: '#ffebee', color: '#c62828' }}
               >
-                🗑️ Tout effacer
+                <span className={styles.optionIcon}>
+                  <TrashIcon />
+                </span>
+                <span className={styles.optionLabel}>
+                  <span className={styles.optionTitle}>Tout effacer</span>
+                  <span className={styles.optionHint}>Réinitialise annotations</span>
+                </span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- apply glassmorphism styling, focus states, and icon/text sub-elements to the demo option buttons using the existing glass variables
- introduce reusable SVG icon components and wrap each option button’s content in structured spans with accessible hints
- extend the CSS module typings so the new option-specific classes are available in TypeScript

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc318758208327b29f5daeaa90e199