### PR TITLE
feat: add adjustable board size control

### DIFF
--- a/demo/App.module.css
+++ b/demo/App.module.css
@@ -488,6 +488,195 @@ body {
   aspect-ratio: 1 / 1;
 }
 
+.boardCanvasContainer {
+  position: relative;
+  display: grid;
+  width: 100%;
+  justify-items: center;
+  align-items: center;
+}
+
+.boardCanvasContainer > :first-child {
+  grid-area: 1 / 1;
+  width: 100%;
+}
+
+.boardSizeControl {
+  grid-area: 1 / 1;
+  justify-self: end;
+  align-self: end;
+  margin: 16px;
+  width: min(220px, calc(100% - 32px));
+  padding: 14px 16px;
+  background: rgba(15, 23, 42, 0.76);
+  border-radius: 16px;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-glass);
+  backdrop-filter: blur(var(--blur-light));
+  -webkit-backdrop-filter: blur(var(--blur-light));
+  display: grid;
+  gap: 10px;
+  z-index: 2;
+}
+
+.boardSizeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.boardSizeLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.boardSizeIcon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
+}
+
+.boardSizeIcon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.boardSizeValue {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-color);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.boardSizeSlider {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.26), rgba(79, 70, 229, 0.68));
+  cursor: pointer;
+  accent-color: var(--accent-color);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+  transition: box-shadow 0.2s ease;
+}
+
+.boardSizeSlider:focus-visible {
+  box-shadow:
+    var(--shadow-glass),
+    0 0 0 3px var(--glass-focus-ring);
+}
+
+.boardSizeSlider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.38);
+}
+
+.boardSizeSlider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.38);
+}
+
+.boardSizeSlider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.boardSizeSlider::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.boardSizeHint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.boardSizePresets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.boardSizePresetButton {
+  flex: 1 1 calc(50% - 8px);
+  min-width: 0;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--glass-border);
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.boardSizePresetButton:hover {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: var(--glass-active-border);
+  color: var(--text-primary);
+}
+
+.boardSizePresetButton:focus-visible {
+  outline: none;
+  box-shadow:
+    var(--shadow-glass),
+    0 0 0 3px var(--glass-focus-ring);
+}
+
+.boardSizePresetButton[aria-pressed='true'] {
+  background: var(--accent-color);
+  border-color: transparent;
+  color: white;
+  box-shadow: var(--shadow-glass);
+}
+
+@media (max-width: 768px) {
+  .boardCanvasContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .boardSizeControl {
+    margin: 0;
+    width: 100%;
+    max-width: none;
+    position: relative;
+  }
+}
+
 .boardWrapper::before {
   content: '';
   position: absolute;

--- a/demo/App.module.css.d.ts
+++ b/demo/App.module.css.d.ts
@@ -36,6 +36,16 @@ declare const styles: {
   readonly themeCreatorLink: string;
   readonly boardWrapper: string;
   readonly boardCanvas: string;
+  readonly boardCanvasContainer: string;
+  readonly boardSizeControl: string;
+  readonly boardSizeHeader: string;
+  readonly boardSizeLabel: string;
+  readonly boardSizeIcon: string;
+  readonly boardSizeValue: string;
+  readonly boardSizeSlider: string;
+  readonly boardSizeHint: string;
+  readonly boardSizePresets: string;
+  readonly boardSizePresetButton: string;
   readonly controlsSection: string;
   readonly panel: string;
   readonly panelHeader: string;


### PR DESCRIPTION
## Summary
- expose board size handling in the React wrapper with memoized style updates
- add a bottom-right board size controller with presets and slider in the demo
- style the new size control and update CSS module typings

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cc41e6c5cc8327b646ae601916eda3