### PR TITLE
feat: capture evaluation annotations

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -131,6 +131,7 @@ export interface PgnMoveAnnotations {
   arrows?: Arrow[];
   circles?: SquareHighlight[];
   textComment?: string;
+  evaluation?: number | string;
 }
 
 export interface PgnMove {
@@ -141,4 +142,8 @@ export interface PgnMove {
   blackComment?: string;
   whiteAnnotations?: PgnMoveAnnotations;
   blackAnnotations?: PgnMoveAnnotations;
+  evaluation?: {
+    white?: number | string;
+    black?: number | string;
+  };
 }

--- a/tests/core/PgnAnnotationParser.test.ts
+++ b/tests/core/PgnAnnotationParser.test.ts
@@ -126,6 +126,20 @@ describe('PgnAnnotationParser', () => {
       });
     });
 
+    describe('Evaluation annotations (%eval)', () => {
+      it('should parse evaluation values as numbers when possible', () => {
+        const result = PgnAnnotationParser.parseComment('{[%eval -0.45] Strong follow-up}');
+        expect(result.evaluation).toBe(-0.45);
+        expect(result.textComment).toBe('Strong follow-up');
+      });
+
+      it('should keep non-numeric evaluation values as strings', () => {
+        const result = PgnAnnotationParser.parseComment('{[%eval #5]}');
+        expect(result.evaluation).toBe('#5');
+        expect(result.textComment).toBe('');
+      });
+    });
+
     describe('Edge cases', () => {
       it('should handle invalid square notation gracefully', () => {
         const result = PgnAnnotationParser.parseComment('%cal Rz9z9,Ra1a2');

--- a/tests/core/PgnNotationAnnotations.test.ts
+++ b/tests/core/PgnNotationAnnotations.test.ts
@@ -121,13 +121,17 @@ describe('PgnNotation with Annotations', () => {
         to: 'e4',
         color: '#ff0000',
       });
-      expect(firstMove.whiteAnnotations?.textComment).toBe('[%eval 0.30] Aggressive push');
+      expect(firstMove.whiteAnnotations?.textComment).toBe('Aggressive push');
+      expect(firstMove.whiteAnnotations?.evaluation).toBe(0.3);
       expect(firstMove.blackAnnotations?.circles).toHaveLength(1);
       expect(firstMove.blackAnnotations?.circles?.[0]).toMatchObject({
         square: 'c5',
         color: '#ff0000',
       });
-      expect(firstMove.blackAnnotations?.textComment).toBe('[%eval 0.25]');
+      expect(firstMove.blackAnnotations?.textComment).toBe('');
+      expect(firstMove.blackAnnotations?.evaluation).toBe(0.25);
+      expect(firstMove.evaluation?.white).toBe(0.3);
+      expect(firstMove.evaluation?.black).toBe(0.25);
 
       const secondMove = moves[1];
       expect(secondMove.moveNumber).toBe(2);
@@ -139,7 +143,8 @@ describe('PgnNotation with Annotations', () => {
         to: 'f3',
         color: '#ff0000',
       });
-      expect(secondMove.whiteAnnotations?.textComment).toBe('[%eval 0.35]');
+      expect(secondMove.whiteAnnotations?.textComment).toBe('');
+      expect(secondMove.whiteAnnotations?.evaluation).toBe(0.35);
       expect(secondMove.blackAnnotations?.arrows).toHaveLength(1);
       expect(secondMove.blackAnnotations?.arrows?.[0]).toMatchObject({
         from: 'd7',
@@ -151,7 +156,10 @@ describe('PgnNotation with Annotations', () => {
         square: 'd6',
         color: '#00ff00',
       });
-      expect(secondMove.blackAnnotations?.textComment).toBe('[%eval 0.10] Solid setup');
+      expect(secondMove.blackAnnotations?.textComment).toBe('Solid setup');
+      expect(secondMove.blackAnnotations?.evaluation).toBe(0.1);
+      expect(secondMove.evaluation?.white).toBe(0.35);
+      expect(secondMove.evaluation?.black).toBe(0.1);
     });
   });
 
@@ -300,6 +308,32 @@ describe('PgnNotation with Annotations', () => {
       expect(pgnWithAnnotations).toContain('%cal Rc7c5');
       expect(pgnWithAnnotations).toContain('%csl Rc5');
       expect(pgnWithAnnotations).toContain('Sicilian Defense');
+    });
+
+    it('should export PGN with evaluation annotations', () => {
+      rules.move({ from: 'e2', to: 'e4' });
+      rules.move({ from: 'e7', to: 'e5' });
+
+      pgnNotation.importFromChessJs(rules.getChessInstance());
+
+      pgnNotation.addMoveAnnotations(1, true, {
+        arrows: [],
+        circles: [],
+        textComment: '',
+        evaluation: -0.75,
+      });
+
+      pgnNotation.addMoveAnnotations(1, false, {
+        arrows: [],
+        circles: [],
+        textComment: 'Solid defence',
+        evaluation: '#3',
+      });
+
+      const pgnWithAnnotations = pgnNotation.toPgnWithAnnotations();
+
+      expect(pgnWithAnnotations).toContain('[%eval -0.75]');
+      expect(pgnWithAnnotations).toContain('[%eval #3] Solid defence');
     });
 
     it('should preserve standard PGN format when no annotations are present', () => {


### PR DESCRIPTION
## Summary
- parse `%eval` directives inside PGN comments and expose the numeric or textual value on parsed annotations
- extend PGN move types and notation handling to retain evaluation data when parsing and when exporting annotated PGNs
- add focused tests that cover evaluation parsing scenarios and exporting comments containing evaluation tags

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ad261c908327a8f19136c5ffcb68