### PR TITLE
Fix click-to-move captures when premoves are enabled

### DIFF
--- a/src/core/NeoChessBoard.ts
+++ b/src/core/NeoChessBoard.ts
@@ -803,6 +803,27 @@ export class NeoChessBoard {
     ctx.restore();
   }
 
+  private _shouldSelectOnPointerDown(square: Square, piece: string): boolean {
+    if (!this._selected || this._selected === square) {
+      return true;
+    }
+
+    const current = this._pieceAt(this._selected);
+    if (!current) {
+      return true;
+    }
+
+    const currentIsWhite = isWhitePiece(current);
+    const nextIsWhite = isWhitePiece(piece);
+
+    if (currentIsWhite === nextIsWhite) {
+      return true;
+    }
+
+    const orientationIsWhite = this.orientation === 'white';
+    return nextIsWhite === orientationIsWhite;
+  }
+
   private _setSelection(square: Square, piece: string): void {
     const side = isWhitePiece(piece) ? 'w' : 'b';
     this._selected = square;
@@ -958,6 +979,12 @@ export class NeoChessBoard {
       const side = isWhitePiece(piece) ? 'w' : 'b';
 
       if (side !== (this.state.turn as any) && !this.allowPremoves) {
+        return;
+      }
+
+      if (!this._shouldSelectOnPointerDown(from, piece)) {
+        this._hoverSq = from;
+        this.renderAll();
         return;
       }
 

--- a/tests/core/NeoChessBoard.test.ts
+++ b/tests/core/NeoChessBoard.test.ts
@@ -705,5 +705,47 @@ describe('NeoChessBoard Core', () => {
       expect((board as any)._selected).toBeNull();
       expect((board as any)._legalCached).toBeNull();
     });
+
+    it('keeps the current selection when clicking an opposing piece for a capture with premoves enabled', () => {
+      board.setFEN('8/8/8/5p2/4P3/8/8/4K2k w - - 0 1');
+      const moveSpy = jest.fn();
+      board.on('move', moveSpy);
+
+      const selectSource = createPointerEventForSquare(0, 'e4');
+      onPointerDown(selectSource.event);
+      onPointerUp(selectSource.event);
+
+      expect((board as any)._selected).toBe('e4');
+      expect((board as any)._dragging).toBeNull();
+
+      const targetClick = createPointerEventForSquare(0, 'f5');
+      onPointerDown(targetClick.event);
+
+      expect((board as any)._selected).toBe('e4');
+      expect((board as any)._dragging).toBeNull();
+
+      onPointerUp(targetClick.event);
+
+      expect(moveSpy).toHaveBeenCalledWith(expect.objectContaining({ from: 'e4', to: 'f5' }));
+      expect((board as any)._pieceAt('f5')).toBe('P');
+      expect((board as any)._pieceAt('e4')).toBeNull();
+      expect((board as any)._selected).toBeNull();
+    });
+
+    it('still allows selecting a friendly piece after selecting an opposing one first', () => {
+      board.setFEN('8/8/8/8/4P3/8/5p2/4K2k w - - 0 1');
+
+      const enemyClick = createPointerEventForSquare(0, 'f2');
+      onPointerDown(enemyClick.event);
+      onPointerUp(enemyClick.event);
+
+      expect((board as any)._selected).toBe('f2');
+
+      const friendlyClick = createPointerEventForSquare(0, 'e4');
+      onPointerDown(friendlyClick.event);
+      onPointerUp(friendlyClick.event);
+
+      expect((board as any)._selected).toBe('e4');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a guard to pointer-down handling so opposing pieces do not replace the active selection when premoves are allowed
- cover the new selection logic with interaction tests for click-to-move captures and friendly reselection

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a40824188327beda5cc8f834c148